### PR TITLE
generate_sl.py can be executed from anywhere (not dependent on the te…

### DIFF
--- a/generate_sl.py
+++ b/generate_sl.py
@@ -20,7 +20,7 @@ DEFAULT_N_PROCESSES = 40
 
 
 def generate_sl(sim_dirs, obs_dirs, station_file, rrup_files, output_dir, prefix, i, np=8):
-    path = os.path.dirname(os.path.realpath(TEMPLATE_NAME))
+    path = os.path.dirname(os.path.abspath(__file__))
     j2_env = Environment(loader=FileSystemLoader(path), trim_blocks=True)
 
     context = j2_env.get_template(TEMPLATE_NAME).render(


### PR DESCRIPTION
…mplate file anymore)

Previously, genearete_sl.py assumed template file is in the directory where generate_sl.py gets executed.  So it had to be executed from the directory where the template file is placed. The limitation meant all the *.sl files are produced in the same location as the source code. 

This fix explicitly states that template file is found in the same directory as "genearte_sl.py", not in the directory where it gets executed.