### PR TITLE
Now working

### DIFF
--- a/IM/read_waveform.py
+++ b/IM/read_waveform.py
@@ -215,12 +215,10 @@ def read_one_station_from_bbseries(
             )  # get timeseries/acc for a station
         elif wave_type == "v":
             waveform.values = bbseries.vel(station=station_name, comp=comp)
-        print("geom only", geom_only)
         if geom_only:  # remove ver
             waveform.values = waveform.values[:, [0, 1]]
     except KeyError:
         sys.exit("station name {} does not exist".format(station_name))
-    print(waveform.values)
     return waveform
 
 

--- a/IM/read_waveform.py
+++ b/IM/read_waveform.py
@@ -212,8 +212,6 @@ def read_one_station_from_bbseries(
         comp = Ellipsis
     else:
         comp = comps
-    print("reading comps", comps)
-    print("comp is", comp)
     try:
         if wave_type == "a":
             waveform.values = bbseries.acc(

--- a/IM/read_waveform.py
+++ b/IM/read_waveform.py
@@ -117,6 +117,7 @@ def read_waveforms(
     bbseis,
     station_names=None,
     comp=Ellipsis,
+    geom_only=False,
     wave_type=None,
     file_type=None,
     units="g",
@@ -138,6 +139,7 @@ def read_waveforms(
         return read_binary_file(
             bbseis,
             comp,
+            geom_only,
             station_names,
             wave_type=wave_type,
             file_type="binary",
@@ -184,7 +186,7 @@ def read_ascii_folder(path, station_names, units="g"):
 
 
 def read_one_station_from_bbseries(
-    bbseries, station_name, comp, wave_type=None, file_type=None
+    bbseries, station_name, comp, geom_only, wave_type=None, file_type=None
 ):
     """
     read one station data into a waveform obj
@@ -213,13 +215,17 @@ def read_one_station_from_bbseries(
             )  # get timeseries/acc for a station
         elif wave_type == "v":
             waveform.values = bbseries.vel(station=station_name, comp=comp)
+        print("geom only", geom_only)
+        if geom_only:  # remove ver
+            waveform.values = waveform.values[:, [0, 1]]
     except KeyError:
         sys.exit("station name {} does not exist".format(station_name))
+    print(waveform.values)
     return waveform
 
 
 def read_binary_file(
-    bbseries, comp, station_names=None, wave_type=None, file_type=None, units="g"
+    bbseries, comp, geom_only, station_names=None, wave_type=None, file_type=None, units="g"
 ):
     """
     read all stations into a list of waveforms
@@ -235,10 +241,10 @@ def read_binary_file(
     #     station_names = bbseries.stations.name
     for station_name in station_names:
         waveform_acc = read_one_station_from_bbseries(
-            bbseries, station_name, comp, wave_type="a", file_type=file_type
+            bbseries, station_name, comp, geom_only, wave_type="a", file_type=file_type
         )  # TODO should create either a or v not both
         waveform_vel = read_one_station_from_bbseries(
-            bbseries, station_name, comp, wave_type="v", file_type=file_type
+            bbseries, station_name, comp, geom_only,  wave_type="v", file_type=file_type
         )
         if units == "cm/s^2":
             waveform_acc.values = waveform_acc.values / 981

--- a/IM/read_waveform.py
+++ b/IM/read_waveform.py
@@ -126,12 +126,10 @@ def read_waveforms(
     :param path:
     :param station_names:
     :param comp:
-    :param geom_only: if True, only return waveform containing 090 and 000 components
     :param wave_type:
     :param file_type:
     :return: a list of waveforms
     """
-
     print(units)
     if file_type == "ascii":
         return read_ascii_folder(path, station_names, units=units)
@@ -192,7 +190,6 @@ def read_one_station_from_bbseries(
     :param bbseries:
     :param station_name:
     :param comp:
-    :param geom_only: if True, only return waveform containing 090 and 000 components
     :param wave_type:
     :param file_type:
     :return: a waveform obj with either acc or vel in values

--- a/IM/read_waveform.py
+++ b/IM/read_waveform.py
@@ -127,6 +127,7 @@ def read_waveforms(
     :param path:
     :param station_names:
     :param comp:
+    :param geom_only: if True, only return waveform containing 090 and 000 components
     :param wave_type:
     :param file_type:
     :return: a list of waveforms
@@ -193,6 +194,7 @@ def read_one_station_from_bbseries(
     :param bbseries:
     :param station_name:
     :param comp:
+    :param geom_only: if True, only return waveform containing 090 and 000 components
     :param wave_type:
     :param file_type:
     :return: a waveform obj with either acc or vel in values

--- a/IM/read_waveform.py
+++ b/IM/read_waveform.py
@@ -224,7 +224,7 @@ def read_one_station_from_bbseries(
     except KeyError:
         sys.exit("station name {} does not exist".format(station_name))
     # keep specified comps (remove 3rd column if comps=[0,1]
-    #waveform.values = waveform.values[:, comps]
+    waveform.values = waveform.values[:, comps]
     return waveform
 
 

--- a/calculate_ims.py
+++ b/calculate_ims.py
@@ -67,7 +67,6 @@ def convert_str_comp(comp, geom_only):
     # if only calc geom, converted_comp = [0, 1]
     if geom_only:
         converted_comp = list(EXT_IDX_DICT.values())[:2]
-        print("converted comp", converted_comp)
     elif comp == "ellipsis":
         converted_comp = Ellipsis
     else:
@@ -75,7 +74,7 @@ def convert_str_comp(comp, geom_only):
     return converted_comp
 
 
-def array_to_dict(value, comp, converted_comp, im, geom_only):
+def array_to_dict(value, comp, converted_comp, im):
     """
     convert a numpy arrary that contains calculated im values to a dict {comp: value}
     :param value:
@@ -86,12 +85,10 @@ def array_to_dict(value, comp, converted_comp, im, geom_only):
     :return: a dict {comp: value}
     """
     value_dict = {}
-    print("convertedddddddd", converted_comp)
-    if converted_comp == Ellipsis or isinstance(converted_comp, list):
+    if converted_comp == Ellipsis or isinstance(converted_comp, list):  # [0, 1]
         comps = list(EXT_IDX_DICT.keys())
-        if geom_only:  # remove ver, as only 090 and 000 are contained in the waveform passed
+        if converted_comp == list(EXT_IDX_DICT.values())[:2]:  # remove ver, as only 090 and 000 are contained in the waveform passed
             comps.remove("ver")
-            print("geom only", comps)
         for c in comps[:-1]:  # excludes geom
             column = EXT_IDX_DICT[c]
             if im == "pSA":  # pSA returns 2d array
@@ -110,7 +107,6 @@ def array_to_dict(value, comp, converted_comp, im, geom_only):
         if im == "MMI":
             value = value.item(0)  # mmi somehow returns a single array instead of a num
         value_dict[comp] = value
-    print("value_dict", value_dict)
     return value_dict
 
 
@@ -172,7 +168,7 @@ def compute_measure_single(value_tuple):
 
         # store a im type values into a dict {comp: np_array/single float}
         # Geometric is also calculated here
-        value_dict = array_to_dict(value, comp, converted_comp, im, geom_only)
+        value_dict = array_to_dict(value, comp, converted_comp, im)
 
         # store value dict into the biggest result dict
         if im == "pSA":
@@ -382,8 +378,7 @@ def write_result(
     output_path = get_result_filepath(output_folder, identifier, ".csv")
     header = get_header(ims, period)
     comp_name, comps = get_comp_name_and_list(comp, geom_only)
-    print("comp+name, comps", comp_name, comps)
-    # print(result_dict, result_dict)
+
     # big csv containing all stations
     with open(output_path, "w") as csv_file:
         csv_writer = csv.writer(csv_file, delimiter=",", quotechar="|")

--- a/calculate_ims.py
+++ b/calculate_ims.py
@@ -87,7 +87,9 @@ def array_to_dict(value, comp, converted_comp, im):
     value_dict = {}
     if converted_comp == Ellipsis or isinstance(converted_comp, list):  # [0, 1]
         comps = list(EXT_IDX_DICT.keys())
-        if converted_comp == list(EXT_IDX_DICT.values())[:2]:  # remove ver, as only 090 and 000 are contained in the waveform passed
+        if (
+            converted_comp == list(EXT_IDX_DICT.values())[:2]
+        ):  # remove ver, as only 090 and 000 are contained in the waveform passed
             comps.remove("ver")
         for c in comps[:-1]:  # excludes geom
             column = EXT_IDX_DICT[c]
@@ -262,7 +264,7 @@ def compute_measures_multiprocess(
         waveforms = read_waveform.read_waveforms(
             input_path,
             bbseries,
-            station_names[i: i + steps],
+            station_names[i : i + steps],
             converted_comp,
             wave_type=wave_type,
             file_type=file_type,

--- a/calculate_ims.py
+++ b/calculate_ims.py
@@ -58,13 +58,17 @@ MEM_PER_CORE = 7.5e8
 MEM_FACTOR = 4
 
 
-def convert_str_comp(comp):
+def convert_str_comp(comp, geom_only):
     """
     convert string comp eg '090'/'ellipsis' to int 0/Ellipsis obj
     :param comp: user input
     :return: converted comp
     """
-    if comp == "ellipsis":
+    # if only calc geom, converted_comp = [0, 1]
+    if geom_only:
+        converted_comp = list(EXT_IDX_DICT.values())[:2]
+        print("converted comp", converted_comp)
+    elif comp == "ellipsis":
         converted_comp = Ellipsis
     else:
         converted_comp = EXT_IDX_DICT[comp]
@@ -131,7 +135,7 @@ def compute_measure_single(value_tuple):
     station_name = waveform_acc.station_name
 
     result[station_name] = {}
-    converted_comp = convert_str_comp(comp)
+    converted_comp = convert_str_comp(comp, geom_only)
 
     for im in ims:
         if im == "PGV":
@@ -244,7 +248,7 @@ def compute_measures_multiprocess(
     :param simple_output:
     :return:
     """
-    converted_comp = convert_str_comp(comp)
+    converted_comp = convert_str_comp(comp, geom_only)
 
     bbseries, station_names = get_bbseis(input_path, file_type, station_names)
 
@@ -261,7 +265,6 @@ def compute_measures_multiprocess(
             bbseries,
             station_names[i: i + steps],
             converted_comp,
-            geom_only,
             wave_type=wave_type,
             file_type=file_type,
             units=units,
@@ -376,7 +379,8 @@ def write_result(
     output_path = get_result_filepath(output_folder, identifier, ".csv")
     header = get_header(ims, period)
     comp_name, comps = get_comp_name_and_list(comp, geom_only)
-
+    print("comp+name, comps", comp_name, comps)
+    print(result_dict, result_dict)
     # big csv containing all stations
     with open(output_path, "w") as csv_file:
         csv_writer = csv.writer(csv_file, delimiter=",", quotechar="|")

--- a/calculate_ims.py
+++ b/calculate_ims.py
@@ -78,12 +78,13 @@ def array_to_dict(value, comp, converted_comp, im, geom_only):
     :param comp:
     :param converted_comp:
     :param im:
+    :param geom_only: if True, remove ver from comps before iteration
     :return: a dict {comp: value}
     """
     value_dict = {}
     if converted_comp == Ellipsis:
         comps = list(EXT_IDX_DICT.keys())
-        if geom_only:  # no need to calculate ver, only 090 and 000 are needed
+        if geom_only:  # remove ver, as only 090 and 000 are contained in the waveform passed
             comps.remove("ver")
         for c in comps[:-1]:  # excludes geom
             column = EXT_IDX_DICT[c]

--- a/calculate_ims.py
+++ b/calculate_ims.py
@@ -258,8 +258,9 @@ def compute_measures_multiprocess(
         waveforms = read_waveform.read_waveforms(
             input_path,
             bbseries,
-            station_names[i : i + steps],
+            station_names[i: i + steps],
             converted_comp,
+            geom_only,
             wave_type=wave_type,
             file_type=file_type,
             units=units,

--- a/calculate_ims.py
+++ b/calculate_ims.py
@@ -86,10 +86,12 @@ def array_to_dict(value, comp, converted_comp, im, geom_only):
     :return: a dict {comp: value}
     """
     value_dict = {}
-    if converted_comp == Ellipsis:
+    print("convertedddddddd", converted_comp)
+    if converted_comp == Ellipsis or isinstance(converted_comp, list):
         comps = list(EXT_IDX_DICT.keys())
         if geom_only:  # remove ver, as only 090 and 000 are contained in the waveform passed
             comps.remove("ver")
+            print("geom only", comps)
         for c in comps[:-1]:  # excludes geom
             column = EXT_IDX_DICT[c]
             if im == "pSA":  # pSA returns 2d array
@@ -108,6 +110,7 @@ def array_to_dict(value, comp, converted_comp, im, geom_only):
         if im == "MMI":
             value = value.item(0)  # mmi somehow returns a single array instead of a num
         value_dict[comp] = value
+    print("value_dict", value_dict)
     return value_dict
 
 
@@ -380,7 +383,7 @@ def write_result(
     header = get_header(ims, period)
     comp_name, comps = get_comp_name_and_list(comp, geom_only)
     print("comp+name, comps", comp_name, comps)
-    print(result_dict, result_dict)
+    # print(result_dict, result_dict)
     # big csv containing all stations
     with open(output_path, "w") as csv_file:
         csv_writer = csv.writer(csv_file, delimiter=",", quotechar="|")

--- a/test/test_calculate_ims/test_calculate_ims.py
+++ b/test/test_calculate_ims/test_calculate_ims.py
@@ -117,14 +117,8 @@ class TestPickleTesting:
                 os.path.join(root_path, INPUT, function + "_im.P"), "rb"
             ) as load_file:
                 im = pickle.load(load_file)
-            with open(
-                os.path.join(root_path, INPUT, function + "_geom_only.P"), "rb"
-            ) as load_file:
-                geom_only = pickle.load(load_file)
 
-            actual_value_dict = calculate_ims.array_to_dict(
-                value, comp, converted_comp, im, geom_only
-            )
+            actual_value_dict = calculate_ims.array_to_dict(value, comp, converted_comp, im)
 
             with open(
                 os.path.join(root_path, OUTPUT, function + "_value_dict.P"), "rb"

--- a/test/test_calculate_ims/test_calculate_ims.py
+++ b/test/test_calculate_ims/test_calculate_ims.py
@@ -117,9 +117,13 @@ class TestPickleTesting:
                 os.path.join(root_path, INPUT, function + "_im.P"), "rb"
             ) as load_file:
                 im = pickle.load(load_file)
+            with open(
+                os.path.join(root_path, INPUT, function + "_geom_only.P"), "rb"
+            ) as load_file:
+                geom_only = pickle.load(load_file)
 
             actual_value_dict = calculate_ims.array_to_dict(
-                value, comp, converted_comp, im
+                value, comp, converted_comp, im, geom_only
             )
 
             with open(

--- a/test/test_calculate_ims/test_calculate_ims.py
+++ b/test/test_calculate_ims/test_calculate_ims.py
@@ -90,7 +90,10 @@ class TestPickleTesting:
                 comp = pickle.load(load_file)
 
             with open(
-                    os.path.join(root_path, INPUT, "compute_measures_multiprocess" + "_geom_only.P"), "rb"
+                os.path.join(
+                    root_path, INPUT, "compute_measures_multiprocess" + "_geom_only.P"
+                ),
+                "rb",
             ) as load_file:
                 geom_only = pickle.load(load_file)
 
@@ -123,7 +126,9 @@ class TestPickleTesting:
             ) as load_file:
                 im = pickle.load(load_file)
 
-            actual_value_dict = calculate_ims.array_to_dict(value, comp, converted_comp, im)
+            actual_value_dict = calculate_ims.array_to_dict(
+                value, comp, converted_comp, im
+            )
 
             with open(
                 os.path.join(root_path, OUTPUT, function + "_value_dict.P"), "rb"
@@ -140,7 +145,10 @@ class TestPickleTesting:
             ) as load_file:
                 value_tuple = pickle.load(load_file)
             with open(
-                    os.path.join(root_path, INPUT, "compute_measures_multiprocess" + "_geom_only.P"), "rb"
+                os.path.join(
+                    root_path, INPUT, "compute_measures_multiprocess" + "_geom_only.P"
+                ),
+                "rb",
             ) as load_file:
                 geom_only = pickle.load(load_file)
             value_tuple += (geom_only,)

--- a/test/test_calculate_ims/test_calculate_ims.py
+++ b/test/test_calculate_ims/test_calculate_ims.py
@@ -89,7 +89,12 @@ class TestPickleTesting:
             ) as load_file:
                 comp = pickle.load(load_file)
 
-            actual_converted_comp = calculate_ims.convert_str_comp(comp)
+            with open(
+                    os.path.join(root_path, INPUT, "compute_measures_multiprocess" + "_geom_only.P"), "rb"
+            ) as load_file:
+                geom_only = pickle.load(load_file)
+
+            actual_converted_comp = calculate_ims.convert_str_comp(comp, geom_only)
 
             with open(
                 os.path.join(root_path, OUTPUT, function + "_converted_comp.P"), "rb"
@@ -134,7 +139,11 @@ class TestPickleTesting:
                 os.path.join(root_path, INPUT, function + "_value_tuple.P"), "rb"
             ) as load_file:
                 value_tuple = pickle.load(load_file)
-
+            with open(
+                    os.path.join(root_path, INPUT, "compute_measures_multiprocess" + "_geom_only.P"), "rb"
+            ) as load_file:
+                geom_only = pickle.load(load_file)
+            value_tuple += geom_only
             actual_result = calculate_ims.compute_measure_single(value_tuple)
 
             with open(

--- a/test/test_calculate_ims/test_calculate_ims.py
+++ b/test/test_calculate_ims/test_calculate_ims.py
@@ -143,7 +143,7 @@ class TestPickleTesting:
                     os.path.join(root_path, INPUT, "compute_measures_multiprocess" + "_geom_only.P"), "rb"
             ) as load_file:
                 geom_only = pickle.load(load_file)
-            value_tuple += geom_only
+            value_tuple += (geom_only,)
             actual_result = calculate_ims.compute_measure_single(value_tuple)
 
             with open(


### PR DESCRIPTION
1. Just to check if the new logic is ok first. Pickle test has been modified but some hardcoded pickle file name will be changed when the logic is accepted. Black format will be in a separate pull

2. Added geom_only flag to convert_str_comp. This way, minimal of changes in functions in calculate_ims is required. Eg. if change the return value of validate_comp to resturn a list of comps, functions like write_result needs to be changed as well.

3.  Added list type checking in read_waveforms and only return waveforms with the compoents specified in the components passed (not checking geom)

4.Tested with pangopango. output csv almost same as benchmark, with 1e-15 difference

5.performace is 39s vs 59s