### PR TITLE
Added EAS calculation as a separate component of FAS

### DIFF
--- a/IM_calculation/IM/im_calculation.py
+++ b/IM_calculation/IM/im_calculation.py
@@ -281,6 +281,11 @@ def calc_FAS(
             f"Attempting to compute fourier spectrum raised exception: {e}\nThis was most likely caused by attempting to compute for a waveform with more than 16384 timesteps."
         )
     else:
+        # compute EAS, the euclidean distance of FAS 000 and 090
+        values_to_store[
+            Components.ceas.str_value
+        ] = intensity_measures.get_euclidean_dist(value[:, 0], value[:, 1])
+
         for comp in comps_to_store:
             if comp.str_value in values_to_store:
                 for i, val in enumerate(im_options[im]):
@@ -437,7 +442,7 @@ def compute_measures_multiprocess(
 
     bbseries, station_names = get_bbseis(input_path, file_type, station_names)
     total_stations = len(station_names)
-    # determine the size of each iteration base on num of processes and mem
+    # determine the size of each iteration base on num of processers and mem
     steps = get_steps(
         input_path, process, total_stations, "FAS" in ims and bbseries.nt > 32768
     )
@@ -481,6 +486,10 @@ def compute_measures_multiprocess(
                     for waveform in waveforms
                 ]
                 all_results.extend(p.starmap(compute_measure_single, array_params))
+                # replace the line above with the below for debugging
+                # for array_param in array_params:
+                #     result=compute_measure_single(*array_param)
+                #     all_results.append(result)
 
     if running_adv_im:
         # read, agg and store csv

--- a/IM_calculation/IM/im_calculation.py
+++ b/IM_calculation/IM/im_calculation.py
@@ -59,7 +59,7 @@ def array_to_dict(value, comps_to_calc, im, comps_to_store):
             value_dict[comps_to_calc[i].str_value] = value[i]
     # In this case, if geom in str_comps,
     # it's guaranteed that 090 and 000 will be present in value_dict
-    if Components.cgeom in comps_to_store and im != 'FAS': #no geom for FAS
+    if Components.cgeom in comps_to_store:
         value_dict[Components.cgeom.str_value] = intensity_measures.get_geom(
             value_dict[Components.c090.str_value], value_dict[Components.c000.str_value]
         )
@@ -282,9 +282,10 @@ def calc_FAS(
         )
     else:
         # compute EAS, the euclidean distance of FAS 000 and 090
-        values_to_store[
-            Components.ceas.str_value
-        ] = intensity_measures.get_euclidean_dist(value[:, 0], value[:, 1])
+        if Components.ceas in comps_to_store:
+            values_to_store[
+                Components.ceas.str_value
+            ] = intensity_measures.get_euclidean_dist(value[:, 0], value[:, 1])
 
         for comp in comps_to_store:
             if comp.str_value in values_to_store:

--- a/IM_calculation/IM/im_calculation.py
+++ b/IM_calculation/IM/im_calculation.py
@@ -442,7 +442,7 @@ def compute_measures_multiprocess(
 
     bbseries, station_names = get_bbseis(input_path, file_type, station_names)
     total_stations = len(station_names)
-    # determine the size of each iteration base on num of processers and mem
+    # determine the size of each iteration base on num of processes and mem
     steps = get_steps(
         input_path, process, total_stations, "FAS" in ims and bbseries.nt > 32768
     )
@@ -486,10 +486,6 @@ def compute_measures_multiprocess(
                     for waveform in waveforms
                 ]
                 all_results.extend(p.starmap(compute_measure_single, array_params))
-                # replace the line above with the below for debugging
-                # for array_param in array_params:
-                #     result=compute_measure_single(*array_param)
-                #     all_results.append(result)
 
     if running_adv_im:
         # read, agg and store csv

--- a/IM_calculation/IM/im_calculation.py
+++ b/IM_calculation/IM/im_calculation.py
@@ -59,7 +59,7 @@ def array_to_dict(value, comps_to_calc, im, comps_to_store):
             value_dict[comps_to_calc[i].str_value] = value[i]
     # In this case, if geom in str_comps,
     # it's guaranteed that 090 and 000 will be present in value_dict
-    if Components.cgeom in comps_to_store:
+    if Components.cgeom in comps_to_store and im != 'FAS': #no geom for FAS
         value_dict[Components.cgeom.str_value] = intensity_measures.get_geom(
             value_dict[Components.c090.str_value], value_dict[Components.c000.str_value]
         )

--- a/IM_calculation/IM/intensity_measures.py
+++ b/IM_calculation/IM/intensity_measures.py
@@ -161,3 +161,14 @@ def get_geom(d1, d2):
     :return: geom value
     """
     return np.sqrt(d1 * d2)
+
+
+def get_euclidean_dist(d1, d2):
+    """
+    get euclidean distance from the 090 and 000 components
+    :param d1: 090
+    :param d2: 000
+    :return: euclidean distance
+    ----------
+    """
+    return np.sqrt(d1 ** 2 + d2 ** 2)

--- a/IM_calculation/scripts/calculate_ims.py
+++ b/IM_calculation/scripts/calculate_ims.py
@@ -123,9 +123,9 @@ def load_args():
         "--components",
         nargs="+",
         choices=list(constants.Components.iterate_str_values()),
-        default=[constants.Components.cgeom.str_value],
+        default=[],  # to be assigned later
         help="Please provide the velocity/acc component(s) you want to calculate eg.geom."
-        " Available compoents are: {} components. Default is all components".format(
+        " Available components are: {} components. Default is geom component".format(
             ",".join(constants.Components.iterate_str_values())
         ),
     )
@@ -185,6 +185,11 @@ def main():
 
     if "FAS" in im:
         im_options["FAS"] = calc.validate_fas_frequency(args.fas_frequency)
+        if constants.Components.ceas.str_value not in args.components:
+            args.components.append(constants.Components.ceas.str_value)
+
+    if len(args.components) == 0:
+        args.components = [constants.Components.cgeom.str_value]
 
     # Create output dir
     utils.setup_dir(args.output_path)

--- a/IM_calculation/scripts/calculate_ims.py
+++ b/IM_calculation/scripts/calculate_ims.py
@@ -176,7 +176,7 @@ def load_args():
                 args.im.remove("FAS")
                 wrong_ims = ",".join(args.im)
         if wrong_ims:
-            parser.error("EAS is not available with the specified IM types: {}".format(wrong_ims))
+            parser.error("The specified IMs need non-EAS components to proceed: {}".format(wrong_ims))
 
     calc.validate_input_path(parser, args.input_path, args.file_type)
     return args

--- a/IM_calculation/scripts/calculate_ims.py
+++ b/IM_calculation/scripts/calculate_ims.py
@@ -125,7 +125,7 @@ def load_args():
         choices=list(constants.Components.iterate_str_values()),
         default= [constants.Components.cgeom.str_value],
         help="Please provide the velocity/acc component(s) you want to calculate eg.geom."
-        " Available components are: {} components. Default is geom component".format(
+        " Available components are: {} components. Default is geom".format(
             ",".join(constants.Components.iterate_str_values())
         ),
     )

--- a/IM_calculation/scripts/calculate_ims.py
+++ b/IM_calculation/scripts/calculate_ims.py
@@ -123,7 +123,7 @@ def load_args():
         "--components",
         nargs="+",
         choices=list(constants.Components.iterate_str_values()),
-        default=[],  # to be assigned later
+        default= [constants.Components.cgeom.str_value],
         help="Please provide the velocity/acc component(s) you want to calculate eg.geom."
         " Available components are: {} components. Default is geom component".format(
             ",".join(constants.Components.iterate_str_values())
@@ -187,9 +187,11 @@ def main():
         im_options["FAS"] = calc.validate_fas_frequency(args.fas_frequency)
         if constants.Components.ceas.str_value not in args.components:
             args.components.append(constants.Components.ceas.str_value)
-
-    if len(args.components) == 0:
-        args.components = [constants.Components.cgeom.str_value]
+        if len(im) == 1: #FAS is the only IM, we can omit geom
+            try:
+                args.components.remove(constants.Components.cgeom.str_value)
+            except ValueError:
+                pass
 
     # Create output dir
     utils.setup_dir(args.output_path)

--- a/IM_calculation/scripts/calculate_ims.py
+++ b/IM_calculation/scripts/calculate_ims.py
@@ -123,7 +123,7 @@ def load_args():
         "--components",
         nargs="+",
         choices=list(constants.Components.iterate_str_values()),
-        default= [constants.Components.cgeom.str_value],
+        default=[constants.Components.cgeom.str_value],
         help="Please provide the velocity/acc component(s) you want to calculate eg.geom."
         " Available components are: {} components. Default is geom".format(
             ",".join(constants.Components.iterate_str_values())
@@ -176,7 +176,11 @@ def load_args():
                 args.im.remove("FAS")
                 wrong_ims = ",".join(args.im)
         if wrong_ims:
-            parser.error("The specified IMs need non-EAS components to proceed: {}".format(wrong_ims))
+            parser.error(
+                "The specified IMs need non-EAS components to proceed: {}".format(
+                    wrong_ims
+                )
+            )
 
     calc.validate_input_path(parser, args.input_path, args.file_type)
     return args


### PR DESCRIPTION
EAS is a Euclidean distance of FAS 000 and 090 components. Instead of handing it as a separate IM of its own, we agreed to regard it as a special component of FAS.

If a user specifies to compute FAS (regardless of what components the user specifies), internally a component "EAS" is added to the comps_to_store list, and if the horizontal components 000 and 090 are not specified by the user, they will be added to the comps_to_calculate list. (Handled by the chance made to qcore, see the separate PR)

The code was tested under a few scenarios:
1. if user specifies FAS with 000 and 090 components, EAS is computed and the output csv contains 000, 090 and EAS
2. if user specifies FAS with 000 only, 090 is internally computed to produce EAS. The output csv contains 000 and EAS.
3. if user specifies FAS with no components, both 000 and 090 are internally computed to obtain EAS. The output csv contains only EAS (no geom)

Known issue: If user specifies FAS alongside other IMs, such as PGA, PGA will have an empty EAS component. FAS on the other hand will have an empty geom component.


