### PR TITLE
Fix:Compute SDI via calculate_ims.py with -a Burks_Baker_2013

### DIFF
--- a/IM_calculation/Advanced_IM/Models/Burks_Baker_2013/run.py
+++ b/IM_calculation/Advanced_IM/Models/Burks_Baker_2013/run.py
@@ -41,7 +41,7 @@ def main(comp_000: Path, comp_090: Path, rotd: bool, output_dir: Path):
     output_dir : Path to the output directory
     """
 
-    output_dir.mkdir(exist_ok=True)
+    output_dir.mkdir(parents=True, exist_ok=True)
 
     log_file = output_dir / "log"
     logging.basicConfig(

--- a/IM_calculation/Advanced_IM/advanced_IM_factory.py
+++ b/IM_calculation/Advanced_IM/advanced_IM_factory.py
@@ -67,7 +67,7 @@ def compute_ims(accelerations, configuration, adv_im_out_dir):
                     ["--timeout_threshold", str(im_config["timeout_threshold"])]
                 )
             # add im specific flags
-            script.extend(configuration.extra_flags)
+            script.extend(configuration.extra_flags[im])
             print(" ".join(script))
             subprocess.run(script)
 

--- a/IM_calculation/Advanced_IM/advanced_IM_factory.py
+++ b/IM_calculation/Advanced_IM/advanced_IM_factory.py
@@ -14,7 +14,7 @@ advanced_im_dir = os.path.dirname(__file__)
 CONFIG_FILE_NAME = os.path.join(advanced_im_dir, "advanced_im_config.yaml")
 
 advanced_im_config = namedtuple(
-    "advanced_im_config", ["IM_list", "config_file", "OpenSees_path"]
+    "advanced_im_config", ["IM_list", "config_file", "OpenSees_path", "extra_flags"]
 )
 COMP_DICT = {"090": 0, "000": 1, "ver": 2}
 
@@ -54,6 +54,9 @@ def compute_ims(accelerations, configuration, adv_im_out_dir):
             ]
             # waveform component sequence
             comp_list = ["000", "090", "ver"]
+            if "required_components" in im_config:
+                comp_list = im_config["required_components"]
+
             script.extend([get_acc_filename(f_dir, station_name, x) for x in comp_list])
             script.extend([out_dir])
 
@@ -63,6 +66,8 @@ def compute_ims(accelerations, configuration, adv_im_out_dir):
                 script.extend(
                     ["--timeout_threshold", str(im_config["timeout_threshold"])]
                 )
+            # add im specific flags
+            script.extend(configuration.extra_flags)
             print(" ".join(script))
             subprocess.run(script)
 

--- a/IM_calculation/Advanced_IM/advanced_im_config.yaml
+++ b/IM_calculation/Advanced_IM/advanced_im_config.yaml
@@ -34,3 +34,4 @@ Taghavi_Miranda_2005:
 Burks_Baker_2013:
   script_location: 'Models/Burks_Baker_2013/run.py'
   timeout_threshold: null
+  required_components: ['000','090']

--- a/IM_calculation/scripts/calculate_ims.py
+++ b/IM_calculation/scripts/calculate_ims.py
@@ -222,6 +222,8 @@ def main():
     if args.advanced_ims is not None:
         components = advanced_IM_factory.COMP_DICT.keys()
         extra_flags = []
+        # TODO: this could utilize check_rotd(), but adds extra complexity handling enums..
+        # TODO: more elegant solution could be desired if more IMs need special care
         if "Burks_Baker_2013" in args.advanced_ims and set(
             ["rotd50", "rotd100", "rotd100_50"]
         ).intersection(args.components):

--- a/IM_calculation/scripts/calculate_ims.py
+++ b/IM_calculation/scripts/calculate_ims.py
@@ -220,13 +220,16 @@ def main():
     station_names = args.station_names
     if args.advanced_ims is not None:
         components = advanced_IM_factory.COMP_DICT.keys()
-        extra_flags = []
+        extra_flags = {}
         # TODO: this could utilize check_rotd(), but adds extra complexity handling enums..
         # TODO: more elegant solution could be desired if more IMs need special care
-        if "Burks_Baker_2013" in args.advanced_ims and set(
-            ["rotd50", "rotd100", "rotd100_50"]
-        ).intersection(args.components):
-            extra_flags.append("--rotd")
+        for adv_im in args.advanced_ims:
+            extra_flags[adv_im] = []
+            if adv_im == "Burks_Baker_2013":
+                if set(["rotd50", "rotd100", "rotd100_50"]).intersection(
+                    args.components
+                ):
+                    extra_flags[adv_im].append("--rotd")
         advanced_im_config = advanced_IM_factory.advanced_im_config(
             args.advanced_ims, args.advanced_im_config, args.OpenSees_path, extra_flags
         )

--- a/IM_calculation/scripts/calculate_ims.py
+++ b/IM_calculation/scripts/calculate_ims.py
@@ -17,6 +17,7 @@ import IM_calculation.IM.im_calculation as calc
 from IM_calculation.Advanced_IM import advanced_IM_factory
 from qcore import utils
 from qcore import constants
+from IM_calculation.IM.im_calculation import check_rotd
 
 
 def load_args():
@@ -220,9 +221,15 @@ def main():
     station_names = args.station_names
     if args.advanced_ims is not None:
         components = advanced_IM_factory.COMP_DICT.keys()
+        extra_flags = []
+        if "Burks_Baker_2013" in args.advanced_ims and set(
+            ["rotd50", "rotd100", "rotd100_50"]
+        ).intersection(args.components):
+            extra_flags.append("--rotd")
         advanced_im_config = advanced_IM_factory.advanced_im_config(
-            args.advanced_ims, args.advanced_im_config, args.OpenSees_path
+            args.advanced_ims, args.advanced_im_config, args.OpenSees_path, extra_flags
         )
+
     else:
         components = args.components
         advanced_im_config = None

--- a/IM_calculation/scripts/calculate_ims.py
+++ b/IM_calculation/scripts/calculate_ims.py
@@ -221,11 +221,11 @@ def main():
     if args.advanced_ims is not None:
         components = advanced_IM_factory.COMP_DICT.keys()
         extra_flags = {}
-        # TODO: this could utilize check_rotd(), but adds extra complexity handling enums..
         # TODO: more elegant solution could be desired if more IMs need special care
         for adv_im in args.advanced_ims:
             extra_flags[adv_im] = []
             if adv_im == "Burks_Baker_2013":
+                # TODO: this could utilize check_rotd(), but adds extra complexity handling enums..
                 if set(["rotd50", "rotd100", "rotd100_50"]).intersection(
                     args.components
                 ):

--- a/IM_calculation/scripts/calculate_ims.py
+++ b/IM_calculation/scripts/calculate_ims.py
@@ -221,15 +221,20 @@ def main():
     if args.advanced_ims is not None:
         components = advanced_IM_factory.COMP_DICT.keys()
         extra_flags = {}
-        # TODO: more elegant solution could be desired if more IMs need special care
+        # TODO: when more IMs need special care, refactor the following block
         for adv_im in args.advanced_ims:
             extra_flags[adv_im] = []
-            if adv_im == "Burks_Baker_2013":
-                # TODO: this could utilize check_rotd(), but adds extra complexity handling enums..
-                if set(["rotd50", "rotd100", "rotd100_50"]).intersection(
-                    args.components
-                ):
+            # TODO: this could utilize check_rotd(), but adds extra complexity handling enums..
+            if set(["rotd50", "rotd100", "rotd100_50"]).intersection(args.components):
+                if adv_im == "Burks_Baker_2013":
                     extra_flags[adv_im].append("--rotd")
+                else:
+                    print(
+                        "rotd calculations are not available for {}: ignored".format(
+                            adv_im
+                        )
+                    )
+
         advanced_im_config = advanced_IM_factory.advanced_im_config(
             args.advanced_ims, args.advanced_im_config, args.OpenSees_path, extra_flags
         )

--- a/IM_calculation/scripts/calculate_ims.py
+++ b/IM_calculation/scripts/calculate_ims.py
@@ -17,7 +17,6 @@ import IM_calculation.IM.im_calculation as calc
 from IM_calculation.Advanced_IM import advanced_IM_factory
 from qcore import utils
 from qcore import constants
-from IM_calculation.IM.im_calculation import check_rotd
 
 
 def load_args():


### PR DESCRIPTION
If -a Burks_Baker_2013 option is used with calculate_ims.py, it failed due to removal of "ver" component argument for run.py 
https://github.com/ucgmsim/IM_calculation/commit/022a9a1800d772da09c1db227cabaeb15f5d3824

Added required_components filed to advanced_im_config.yaml, so that a different set of components can be used for a specific IM.

Also added a hack to pass --rotd flag to run.py. For now, SDI is the only one that needs special care - will need to devise a better solution if more IMs need to be looked after