### PR TITLE
If no station is found, throw an error

### DIFF
--- a/IM_calculation/IM/im_calculation.py
+++ b/IM_calculation/IM/im_calculation.py
@@ -433,6 +433,7 @@ def get_bbseis(input_path, file_type, selected_stations, real_only=False):
             for stat_name in station_names
             if not shared.is_virtual_station(stat_name)
         ]
+    assert len(station_names) > 0, "No station is found"
     return bbseries, station_names
 
 
@@ -675,6 +676,7 @@ def get_steps(input_path, nps, total_stations, high_mem_usage=False):
     if high_mem_usage:
         estimated_mem *= MEM_FACTOR
     available_mem = nps * MEM_PER_CORE
+    assert estimated_mem > 0, f"Estimated memory is 0: Check {input_path}"
     batches = np.ceil(np.divide(estimated_mem, available_mem))
     steps = int(np.floor(np.divide(total_stations, batches)))
     if steps == 0:


### PR DESCRIPTION
Vahid reported this issue. 
When there is no data for observation directory, it should throw an error and stop.
Currently, it proceeds, and breaks at  get_steps()

```
/home/vlo23/IM_calculation/IM_calculation/IM/im_calculation.py:679: RuntimeWarning: invalid value encountered in true_divide
  steps = int(np.floor(np.divide(total_stations, batches)))
Traceback (most recent call last):
  File "/home/vlo23/IM_calculation/IM_calculation/scripts/calculate_ims.py", line 271, in <module>
    main()
  File "/home/vlo23/IM_calculation/IM_calculation/scripts/calculate_ims.py", line 264, in main
    real_only=args.real_stats_only,
  File "/home/vlo23/IM_calculation/IM_calculation/IM/im_calculation.py", line 497, in compute_measures_multiprocess
    input_path, process, total_stations, "FAS" in ims and bbseries.nt > 32768
  File "/home/vlo23/IM_calculation/IM_calculation/IM/im_calculation.py", line 679, in get_steps
    steps = int(np.floor(np.divide(total_stations, batches)))
ValueError: cannot convert float NaN to integer
```
If total_stations =0, batches = 0, this ValueError happens