### PR TITLE
PG\* rotd50 was taking the median etc off the wrong axis.

### DIFF
--- a/IM_calculation/IM/im_calculation.py
+++ b/IM_calculation/IM/im_calculation.py
@@ -100,10 +100,17 @@ def check_rotd(comps_to_store: Iterable[Components]) -> bool:
 def calculate_rotd(
     accelerations,
     comps_to_store: List[Components],
-    func=lambda x: np.max(np.abs(x), axis=1),
+    func=lambda x: np.max(np.abs(x), axis=-2),
 ):
     """
     Calculates rotd for given accelerations
+
+    Multiplying the waveforms by the rotation matrices gives an array with shape either
+    (periods, nt, n_rotations) (for pSA) or (nt, n_rotations) (for single dimension IMs).
+    The max is taken over the second axis from the rear (nt),
+    so for pSA we get an array with shape (periods, n_rotations), while single dimension IMs gets (n_rotations)
+    Which is then taken the median for RotD50 and the maximum for RotD100
+
     :param accelerations: An array with shape [[periods.size,] nt, 2]
         where the first axis is optional and if present is equal to the number of periods in the intensity measure.
         nt is the number of timesteps in the original waveform
@@ -228,7 +235,7 @@ def calc_PG(waveform, im, comps_to_store, comps_to_calculate):
     value = intensity_measures.get_max_nd(waveform)
     values = array_to_dict(value, comps_to_calculate, im, comps_to_store)
     if check_rotd(comps_to_store):
-        rotd = calculate_rotd(waveform, comps_to_store, func=lambda x: np.max(np.abs(x), axis=0))
+        rotd = calculate_rotd(waveform, comps_to_store)
         sanitise_single_value_arrays(rotd)
         values.update(rotd)
     return values

--- a/IM_calculation/IM/im_calculation.py
+++ b/IM_calculation/IM/im_calculation.py
@@ -228,7 +228,7 @@ def calc_PG(waveform, im, comps_to_store, comps_to_calculate):
     value = intensity_measures.get_max_nd(waveform)
     values = array_to_dict(value, comps_to_calculate, im, comps_to_store)
     if check_rotd(comps_to_store):
-        rotd = calculate_rotd(waveform, comps_to_store)
+        rotd = calculate_rotd(waveform, comps_to_store, func=lambda x: np.max(np.abs(x), axis=0))
         sanitise_single_value_arrays(rotd)
         values.update(rotd)
     return values

--- a/IM_calculation/IM/intensity_measures.py
+++ b/IM_calculation/IM/intensity_measures.py
@@ -78,7 +78,7 @@ def calculate_Nstep(DT, NT):
 
 def get_rotations(
     accelerations,
-    func=lambda x: np.max(np.abs(x), axis=1),
+    func=lambda x: np.max(np.abs(x), axis=-2),
     delta_theta: int = 1,
     min_angle: int = 0,
     max_angle: int = 180,


### PR DESCRIPTION
Answers before:
![image](https://user-images.githubusercontent.com/25143301/131758607-6e0bd917-3a7b-4835-84c0-95d6349d9f95.png)
Answers after:
![image](https://user-images.githubusercontent.com/25143301/131758580-be25cd9d-e421-4a3d-9f1d-f14f0ca089bf.png)

Unsure if other IMs such as SDI are affected (but because it's multi-dimensional; it's probably okay like pSA)
