### PR TITLE
Fix hypocentre origin calculation

### DIFF
--- a/IM_calculation/source_site_dist/src_site_dist.py
+++ b/IM_calculation/source_site_dist/src_site_dist.py
@@ -189,7 +189,7 @@ def calc_rx_ry_GC2(
         # Will only use the first one found if there are multiple
         for plane in plane_infos:
             if plane["shyp"] != -999.9000:
-                origin_offset = length / 2 + plane["shyp"]
+                origin_offset = -(length / 2 + plane["shyp"])
                 break
 
     for i, loc in enumerate(locations):

--- a/IM_calculation/source_site_dist/src_site_dist.py
+++ b/IM_calculation/source_site_dist/src_site_dist.py
@@ -184,13 +184,12 @@ def calc_rx_ry_GC2(
 
     origin_offset = 0
     if hypocentre_origin:
+        length = sum([plane["length"] for plane in plane_infos])
         # Our faults only use one hypocentre
         # Will only use the first one found if there are multiple
         for plane in plane_infos:
-            if plane["shyp"] == -999.9000:
-                origin_offset -= plane["length"]
-            else:
-                origin_offset -= plane["length"] / 2 + plane["shyp"]
+            if plane["shyp"] != -999.9000:
+                origin_offset = length / 2 + plane["shyp"]
                 break
 
     for i, loc in enumerate(locations):


### PR DESCRIPTION
The srf header information seems to be incorrect, the first plane always seems to have the shyp value, except for the whole fault, instead of just the plane