### PR TITLE
Nonlinear sdi

### DIFF
--- a/IM_calculation/Advanced_IM/Models/Burks_Baker_2013/run.py
+++ b/IM_calculation/Advanced_IM/Models/Burks_Baker_2013/run.py
@@ -56,14 +56,11 @@ def main(comp_000: Path, comp_090: Path, rotd: bool, output_dir: Path):
     waveforms["000"], meta = read_ascii(comp_000, meta=True)
     waveforms["090"] = read_ascii(comp_090)
     DT = np.float32(meta["dt"])  # to match the behaviour of basic SDI
-    NT = meta["nt"]
 
     results = {}
 
     accelerations = np.array((waveforms["000"], waveforms["090"])).T
     ordered_columns_dict = {}
-    sd_rotd_list = []
-
 
     for z in z_list:
         for dt in dt_list:

--- a/IM_calculation/Advanced_IM/Models/Burks_Baker_2013/run.py
+++ b/IM_calculation/Advanced_IM/Models/Burks_Baker_2013/run.py
@@ -94,22 +94,19 @@ def main(comp_000: Path, comp_090: Path, rotd: bool, output_dir: Path):
                         for j, im_name in enumerate(im_names):
                             results[component.str_value][im_name] = sdi_values[j, i]
 
+
                     # computing non-linear rotd
-                    for i in range(0,181):
-                        theta = i*np.pi / 180
-                        rotd_acc = accelerations[:,0]*np.cos(theta)+accelerations[:,1]*np.sin(theta)
+                    rotd_accs = intensity_measures.get_rotations(accelerations[..., [0, 1]], max_angle=180, func=lambda x: x)
 
-                        displacements = (
-                            intensity_measures.get_SDI_nd(
-                                rotd_acc, period, DT, z, alpha, dy, dt
-                            )
-                            * 100  # Burks & Baker returns m, but output is stored in cm
+                    displacements_array = (
+                        intensity_measures.get_SDI_nd(
+                            rotd_accs, period, DT, z, alpha, dy, dt
                         )
-                        sdi_values = np.max(np.abs(displacements), axis=1)
-                        sd_rotd_list.append(sdi_values)
+                        * 100
+                    )
 
-                    rotd_values = im_calculation.calculate_rotd(
-                        np.array(sd_rotd_list).T, rotd_comps, is_input_rotd=True
+                    rotd_values = im_calculation.get_rotd_components_dict(
+                        np.max(np.abs(displacements_array), axis=1), rotd_comps
                     )
 
                     for component in rotd_comps:

--- a/IM_calculation/Advanced_IM/Models/Burks_Baker_2013/run.py
+++ b/IM_calculation/Advanced_IM/Models/Burks_Baker_2013/run.py
@@ -27,7 +27,6 @@ z_list = [0.05]  # damping ratio
 alpha_list = [0.0001]  # strain hardening ratio
 dy_list = [0.21278]  # strain hardening ratio
 dt_list = [0.005]
-g = 9.81
 
 period = np.array([0.5, 3.0])
 

--- a/IM_calculation/Advanced_IM/Models/Burks_Baker_2013/run.py
+++ b/IM_calculation/Advanced_IM/Models/Burks_Baker_2013/run.py
@@ -65,13 +65,21 @@ def main(comp_000: Path, comp_090: Path, rotd: bool, output_dir: Path):
         for dt in dt_list:
             for alpha in alpha_list:
                 for dy in dy_list:
-                    displacements = (
-                        intensity_measures.get_SDI_nd(
-                            accelerations, period, NT, DT, z, alpha, dy, dt
+                    for i in range(0,181):
+                        theta = i*np.pi / 180
+                        rotD_comp = accelerations[0]*np.cos(theta)+accelerations[1]*np.sin(theta)
+                        t_end =NT*DT
+                        t = np.arange(DT, t_end, DT)
+                        ag_rotd = rotD_comp*g / 100
+
+                        displacements = (
+                            intensity_measures.get_SDI_nd(
+                                ag_rotd, period, NT, DT, z, alpha, dy, dt
+                            ) # Binlinear_Newmark_withTH(period,z,dy, alpha, accelerations/100*G,DT,dt)
+                            * 100  # Burks & Baker returns m, but output is stored in cm
                         )
-                        * 100  # Burks & Baker returns m, but output is stored in cm
-                    )
                     sdi_values = np.max(np.abs(displacements), axis=1)
+
                     im_names = []
                     for t in period:
                         im_name = f"SDI_{t}_dy{dy}_a{alpha}_dt{dt}_z{z}"
@@ -88,6 +96,7 @@ def main(comp_000: Path, comp_090: Path, rotd: bool, output_dir: Path):
                             results[component.str_value][im_name] = sdi_values[j, i]
                     if not rotd:
                         continue
+
                     rotd_values = im_calculation.calculate_rotd(
                         displacements, rotd_comps
                     )

--- a/IM_calculation/Advanced_IM/Models/Burks_Baker_2013/run.py
+++ b/IM_calculation/Advanced_IM/Models/Burks_Baker_2013/run.py
@@ -71,11 +71,10 @@ def main(comp_000: Path, comp_090: Path, rotd: bool, output_dir: Path):
                     for i in range(0,181):
                         theta = i*np.pi / 180
                         rotD_comp = accelerations[:,0]*np.cos(theta)+accelerations[:,1]*np.sin(theta)
-                        ag_rotd = rotD_comp*g #/ 100
 
                         displacements = (
                             intensity_measures.get_SDI_nd(
-                                ag_rotd, period, DT, z, alpha, dy, dt
+                                rotD_comp, period, DT, z, alpha, dy, dt
                             ) # Binlinear_Newmark_withTH(period,z,dy, alpha, accelerations/100*G,DT,dt)
                             #* 100  # Burks & Baker returns m, but output is stored in cm
                         )

--- a/IM_calculation/Advanced_IM/Models/Burks_Baker_2013/run.py
+++ b/IM_calculation/Advanced_IM/Models/Burks_Baker_2013/run.py
@@ -96,18 +96,8 @@ def main(comp_000: Path, comp_090: Path, rotd: bool, output_dir: Path):
 
 
                     # computing non-linear rotd
-                    rotd_accs = intensity_measures.get_rotations(accelerations[..., [0, 1]], max_angle=180, func=lambda x: x)
-
-                    displacements_array = (
-                        intensity_measures.get_SDI_nd(
-                            rotd_accs, period, DT, z, alpha, dy, dt
-                        )
-                        * 100
-                    )
-
-                    rotd_values = im_calculation.get_rotd_components_dict(
-                        np.max(np.abs(displacements_array), axis=1), rotd_comps
-                    )
+                    func = lambda x: np.max(np.abs(intensity_measures.get_SDI_nd(x, period, DT, z, alpha, dy, dt) * 100), axis=1)
+                    rotd_values = im_calculation.calculate_rotd(accelerations[..., [0, 1]],rotd_comps, func=func)
 
                     for component in rotd_comps:
                         if component.str_value not in results:

--- a/IM_calculation/Advanced_IM/Models/Burks_Baker_2013/run.py
+++ b/IM_calculation/Advanced_IM/Models/Burks_Baker_2013/run.py
@@ -93,8 +93,8 @@ def main(comp_000: Path, comp_090: Path, rotd: bool, output_dir: Path):
                             results[component.str_value] = {}
                         for j, im_name in enumerate(im_names):
                             results[component.str_value][im_name] = sdi_values[j, i]
-
-
+                    if not rotd:
+                        continue
                     # computing non-linear rotd
                     func = lambda x: np.max(np.abs(intensity_measures.get_SDI_nd(x, period, DT, z, alpha, dy, dt) * 100), axis=1)
                     rotd_values = im_calculation.calculate_rotd(accelerations[..., [0, 1]],rotd_comps, func=func)

--- a/IM_calculation/Advanced_IM/Models/Burks_Baker_2013/run.py
+++ b/IM_calculation/Advanced_IM/Models/Burks_Baker_2013/run.py
@@ -62,6 +62,7 @@ def main(comp_000: Path, comp_090: Path, rotd: bool, output_dir: Path):
     accelerations = np.array((waveforms["000"], waveforms["090"])).T
     ordered_columns_dict = {}
 
+    #TODO: replace the quad for loop with itertools.product (Would reduce the indentation by 3 levels)
     for z in z_list:
         for dt in dt_list:
             for alpha in alpha_list:

--- a/IM_calculation/IM/im_calculation.py
+++ b/IM_calculation/IM/im_calculation.py
@@ -99,6 +99,7 @@ def calculate_rotd(
     accelerations,
     comps_to_store: List[Components],
     func=lambda x: np.max(np.abs(x), axis=-2),
+    is_input_rotd=False
 ):
     """
     Calculates rotd for given accelerations
@@ -117,7 +118,10 @@ def calculate_rotd(
     :return: A dictionary with the comps_to_store as keys, and 1d arrays of shape [periods.size] containing the rotd values
     """
     # Selects the first two basic components. get_comps_to_calc_and_store makes sure that the first two are 000 and 090
-    rotd = intensity_measures.get_rotations(accelerations[..., [0, 1]], func=func)
+    if is_input_rotd:
+        rotd = accelerations
+    else:
+        rotd = intensity_measures.get_rotations(accelerations[..., [0, 1]], func=func)
     value_dict = {}
 
     rotd50 = np.median(rotd, axis=-1)

--- a/IM_calculation/IM/im_calculation.py
+++ b/IM_calculation/IM/im_calculation.py
@@ -95,32 +95,6 @@ def check_rotd(comps_to_store: Iterable[Components]) -> bool:
     )
 
 
-def get_rotd_components_dict(
-        rotd,
-        comps_to_store:  List[Components]
-):
-
-    """
-    Compute median and max for given rotd and return the result as a dictionary with the comps_to_store as keys
-     
-    :param rotd:  An array of shape [periods.size, nt, (max_angle-min_angle)/delta_theta] containing rotd values
-    :param comps_to_store: A list of components to store
-    :return: A dictionary with the comps_to_store as keys, and 1d arrays of shape [periods.size] containing the rotd values
-    """
-    value_dict = {}
-
-    rotd50 = np.median(rotd, axis=-1)
-    rotd100 = np.max(rotd, axis=-1)
-
-    if Components.crotd50 in comps_to_store:
-        value_dict[Components.crotd50.str_value] = rotd50
-    if Components.crotd100 in comps_to_store:
-        value_dict[Components.crotd100.str_value] = rotd100
-    if Components.crotd100_50 in comps_to_store:
-        value_dict[Components.crotd100_50.str_value] = rotd100 / rotd50
-
-    return value_dict
-
 def calculate_rotd(
     accelerations,
     comps_to_store: List[Components],
@@ -142,12 +116,20 @@ def calculate_rotd(
     :param func: The function to apply to the rotated waveforms. Defaults to taking the maximum absolute value across all rotations (used by PGA, PGV, pSA)
     :return: A dictionary with the comps_to_store as keys, and 1d arrays of shape [periods.size] containing the rotd values
     """
-
     # Selects the first two basic components. get_comps_to_calc_and_store makes sure that the first two are 000 and 090
     rotd = intensity_measures.get_rotations(accelerations[..., [0, 1]], func=func)
+    value_dict = {}
 
-    return get_rotd_components_dict(rotd,comps_to_store)
+    rotd50 = np.median(rotd, axis=-1)
+    rotd100 = np.max(rotd, axis=-1)
 
+    if Components.crotd50 in comps_to_store:
+        value_dict[Components.crotd50.str_value] = rotd50
+    if Components.crotd100 in comps_to_store:
+        value_dict[Components.crotd100.str_value] = rotd100
+    if Components.crotd100_50 in comps_to_store:
+        value_dict[Components.crotd100_50.str_value] = rotd100 / rotd50
+    return value_dict
 
 
 def compute_adv_measure(waveform, advanced_im_config, output_dir):

--- a/IM_calculation/IM/intensity_measures.py
+++ b/IM_calculation/IM/intensity_measures.py
@@ -53,7 +53,7 @@ def get_SDI(acceleration, period, DT, z, alpha, dy, dt):
     ).T
 
 
-def get_SDI_nd(acceleration, period, NT, DT, z, alpha, dy, dt):
+def get_SDI_nd(acceleration, period, DT, z, alpha, dy, dt):
     # SDI
     if acceleration.ndim != 1:
         ts, dims = acceleration.shape
@@ -69,7 +69,7 @@ def get_SDI_nd(acceleration, period, NT, DT, z, alpha, dy, dt):
 
         return displacements
     else:
-        return get_SDI(acceleration, period, NT, DT, z, alpha, dy, dt)
+        return get_SDI(acceleration, period, DT, z, alpha, dy, dt)
 
 
 def calculate_Nstep(DT, NT):


### PR DESCRIPTION
On request from @Vahid-Loghman  and @lee-robin .

rotd_values are now obtained by rotating first, then Burks_Baker_2013. Previously it computed the displacements from Burks_Baker_2013 first, then rotated them. 

@Vahid-Loghman verified the output from this code.