### PR TITLE
change for when dt<0.05

### DIFF
--- a/IM_calculation/IM/im_calculation.py
+++ b/IM_calculation/IM/im_calculation.py
@@ -555,6 +555,8 @@ def compute_measures_multiprocess(
                     for ii, waveform in enumerate(waveforms, start=i + 1)
                 ]
                 all_results.extend(p.starmap(compute_measure_single, array_params))
+                # for i in array_params:
+                #     all_results.extend(compute_measure_single(*i))
             p_t(i)
 
     if running_adv_im:

--- a/IM_calculation/IM/im_calculation.py
+++ b/IM_calculation/IM/im_calculation.py
@@ -555,8 +555,6 @@ def compute_measures_multiprocess(
                     for ii, waveform in enumerate(waveforms, start=i + 1)
                 ]
                 all_results.extend(p.starmap(compute_measure_single, array_params))
-                # for i in array_params:
-                #     all_results.extend(compute_measure_single(*i))
             p_t(i)
 
     if running_adv_im:

--- a/IM_calculation/IM/intensity_measures.py
+++ b/IM_calculation/IM/intensity_measures.py
@@ -31,8 +31,10 @@ def get_spectral_acceleration(acceleration, period, NT, DT, Nstep, delta_t=DELTA
 
 def get_spectral_acceleration_nd(acceleration, period, NT, DT):
     # pSA
+    # Uses string conversion to convert from a float32 to a python float while retaining prescision
+    # https://stackoverflow.com/questions/41967222/how-to-retain-precision-when-converting-from-float32-to-float
     delta_t = min(float(str(DT)), DELTA_T)
-    print(delta_t, DT, DELTA_T)
+
     if acceleration.ndim != 1:
         ts, dims = acceleration.shape
         Nstep = calculate_Nstep(DT, NT, delta_t)

--- a/IM_calculation/IM/intensity_measures.py
+++ b/IM_calculation/IM/intensity_measures.py
@@ -31,7 +31,8 @@ def get_spectral_acceleration(acceleration, period, NT, DT, Nstep, delta_t=DELTA
 
 def get_spectral_acceleration_nd(acceleration, period, NT, DT):
     # pSA
-    delta_t = min(DT, DELTA_T)
+    delta_t = min(float(str(DT)), DELTA_T)
+    print(delta_t, DT, DELTA_T)
     if acceleration.ndim != 1:
         ts, dims = acceleration.shape
         Nstep = calculate_Nstep(DT, NT, delta_t)

--- a/IM_calculation/IM/intensity_measures.py
+++ b/IM_calculation/IM/intensity_measures.py
@@ -12,7 +12,7 @@ def get_max_nd(data):
     return np.max(np.abs(data), axis=0)
 
 
-def get_spectral_acceleration(acceleration, period, NT, DT, Nstep):
+def get_spectral_acceleration(acceleration, period, NT, DT, Nstep, delta_t=DELTA_T):
     # pSA
     c = 0.05
     M = 1.0
@@ -24,21 +24,22 @@ def get_spectral_acceleration(acceleration, period, NT, DT, Nstep):
 
     # interpolation additions
     t_orig = np.arange(NT + 1) * DT
-    t_solve = np.arange(Nstep) * DELTA_T
+    t_solve = np.arange(Nstep) * delta_t
     acc_step = np.interp(t_solve, t_orig, acc_step)
-    return rspectra.Response_Spectra(acc_step, DELTA_T, c, period, M, gamma, beta)
+    return rspectra.Response_Spectra(acc_step, delta_t, c, period, M, gamma, beta)
 
 
 def get_spectral_acceleration_nd(acceleration, period, NT, DT):
     # pSA
     if acceleration.ndim != 1:
         ts, dims = acceleration.shape
-        Nstep = calculate_Nstep(DT, NT)
+        delta_t = min(DT, DELTA_T)
+        Nstep = calculate_Nstep(DT, NT, delta_t)
         accelerations = np.zeros((period.size, Nstep, dims))
 
         for i in range(dims):
             accelerations[:, :, i] = get_spectral_acceleration(
-                acceleration[:, i], period, NT, DT, Nstep
+                acceleration[:, i], period, NT, DT, Nstep, delta_t
             )
 
         return accelerations
@@ -72,8 +73,8 @@ def get_SDI_nd(acceleration, period, NT, DT, z, alpha, dy, dt):
         return get_SDI(acceleration, period, NT, DT, z, alpha, dy, dt)
 
 
-def calculate_Nstep(DT, NT):
-    return NT * int(round(DT / DELTA_T))
+def calculate_Nstep(DT, NT, delta_t=DELTA_T):
+    return NT * int(round(DT / delta_t))
 
 
 def get_rotations(

--- a/IM_calculation/IM/intensity_measures.py
+++ b/IM_calculation/IM/intensity_measures.py
@@ -31,9 +31,9 @@ def get_spectral_acceleration(acceleration, period, NT, DT, Nstep, delta_t=DELTA
 
 def get_spectral_acceleration_nd(acceleration, period, NT, DT):
     # pSA
+    delta_t = min(DT, DELTA_T)
     if acceleration.ndim != 1:
         ts, dims = acceleration.shape
-        delta_t = min(DT, DELTA_T)
         Nstep = calculate_Nstep(DT, NT, delta_t)
         accelerations = np.zeros((period.size, Nstep, dims))
 
@@ -44,7 +44,7 @@ def get_spectral_acceleration_nd(acceleration, period, NT, DT):
 
         return accelerations
     else:
-        return get_spectral_acceleration(acceleration, period, NT, DT)
+        return get_spectral_acceleration(acceleration, period, NT, DT, delta_t)
 
 
 def get_SDI(acceleration, period, DT, z, alpha, dy, dt):


### PR DESCRIPTION
IM Calc was crashing when BB_DTs < 0.005 were encountered. 

The solution was to use a minimum for the DELTA_T constant. There were some minor floating point conversion issues which unfortunately broke backwards compatibility.