### PR TITLE
Added cutoff for SNR / FAS

### DIFF
--- a/IM_calculation/IM/im_calculation.py
+++ b/IM_calculation/IM/im_calculation.py
@@ -151,7 +151,7 @@ def compute_measure_single(
     comps_to_store,
     im_options,
     comps_to_calculate,
-    progress = None,
+    progress=None,
     logger=qclogging.get_basic_logger(),
 ):
     """
@@ -645,14 +645,13 @@ def compute_measures_multiprocess(
         components_to_store,
     ) = constants.Components.get_comps_to_calc_and_store(comp)
 
+    # bbseries can be none after this step if using ascii input files
     bbseries, station_names = get_bbseis(
         input_path, file_type, station_names, real_only=real_only
     )
     total_stations = len(station_names)
     # determine the size of each iteration base on num of processes and mem
-    steps = get_steps(
-        input_path, process, total_stations, "FAS" in ims
-    )
+    steps = get_steps(input_path, process, total_stations, "FAS" in ims)
 
     # initialize result list for basic IM
     if not running_adv_im:

--- a/IM_calculation/IM/snr_calculation.py
+++ b/IM_calculation/IM/snr_calculation.py
@@ -38,6 +38,7 @@ def get_snr_from_waveform(
     apply_smoothing: bool = True,
     ko_matrix_path: Path = None,
     common_frequency_vector: np.asarray = None,
+    filename: str = None
 ):
     """
     Calculates the SNR of a waveform given a tp and common frequency vector
@@ -76,8 +77,12 @@ def get_snr_from_waveform(
         return None, None, None, None, None, None
 
     # Add the tapering to the signal and noise
-    taper_signal_acc = apply_taper(signal_acc)
-    taper_noise_acc = apply_taper(noise_acc)
+    try:
+        taper_signal_acc = apply_taper(signal_acc)
+        taper_noise_acc = apply_taper(noise_acc)
+    except Exception as e:
+        print(f"Error {e}")
+        print(f"Waveform {filename}")
 
     # Generate FFT for the signal and noise
     fas_signal, frequency_signal = computeFAS.generate_fa_spectrum(

--- a/IM_calculation/IM/snr_calculation.py
+++ b/IM_calculation/IM/snr_calculation.py
@@ -80,7 +80,7 @@ def get_snr_from_waveform(
     try:
         taper_signal_acc = apply_taper(signal_acc)
         taper_noise_acc = apply_taper(noise_acc)
-    except UserWarning as warning:
+    except RuntimeWarning as warning:
         print("Caught warning:", warning)
         # print(f"Error {e}")
         print(f"Waveform {filename}")

--- a/IM_calculation/IM/snr_calculation.py
+++ b/IM_calculation/IM/snr_calculation.py
@@ -38,7 +38,6 @@ def get_snr_from_waveform(
     apply_smoothing: bool = True,
     ko_matrix_path: Path = None,
     common_frequency_vector: np.asarray = None,
-    filename: str = None
 ):
     """
     Calculates the SNR of a waveform given a tp and common frequency vector
@@ -77,14 +76,8 @@ def get_snr_from_waveform(
         return None, None, None, None, None, None
 
     # Add the tapering to the signal and noise
-    # print(f"Waveform {filename}")
-    try:
-        taper_signal_acc = apply_taper(signal_acc)
-        taper_noise_acc = apply_taper(noise_acc)
-    except RuntimeWarning as warning:
-        print("Caught warning:", warning)
-        # print(f"Error {e}")
-        print(f"Waveform {filename}")
+    taper_signal_acc = apply_taper(signal_acc)
+    taper_noise_acc = apply_taper(noise_acc)
 
     # Generate FFT for the signal and noise
     fas_signal, frequency_signal = computeFAS.generate_fa_spectrum(

--- a/IM_calculation/IM/snr_calculation.py
+++ b/IM_calculation/IM/snr_calculation.py
@@ -77,7 +77,7 @@ def get_snr_from_waveform(
         return None, None, None, None, None, None
 
     # Add the tapering to the signal and noise
-    print(f"Waveform {filename}")
+    # print(f"Waveform {filename}")
     try:
         taper_signal_acc = apply_taper(signal_acc)
         taper_noise_acc = apply_taper(noise_acc)

--- a/IM_calculation/IM/snr_calculation.py
+++ b/IM_calculation/IM/snr_calculation.py
@@ -80,8 +80,9 @@ def get_snr_from_waveform(
     try:
         taper_signal_acc = apply_taper(signal_acc)
         taper_noise_acc = apply_taper(noise_acc)
-    except Exception as e:
-        print(f"Error {e}")
+    except UserWarning as warning:
+        print("Caught warning:", warning)
+        # print(f"Error {e}")
         print(f"Waveform {filename}")
 
     # Generate FFT for the signal and noise

--- a/IM_calculation/IM/snr_calculation.py
+++ b/IM_calculation/IM/snr_calculation.py
@@ -77,6 +77,7 @@ def get_snr_from_waveform(
         return None, None, None, None, None, None
 
     # Add the tapering to the signal and noise
+    print(f"Waveform {filename}")
     try:
         taper_signal_acc = apply_taper(signal_acc)
         taper_noise_acc = apply_taper(noise_acc)

--- a/IM_calculation/examples/waveform_snr.py
+++ b/IM_calculation/examples/waveform_snr.py
@@ -40,7 +40,7 @@ tp = 1320
 # common_freqs = np.logspace(np.log10(0.05), np.log10(50), num=100, base=10.0)
 
 (snr, frequencies, fas_signal, fas_noise, Ds, Dn) = snr_calc.get_snr_from_waveform(
-    waveform, tp, common_frequency_vector=None
+    waveform, tp, DT, common_frequency_vector=None
 )
 
 if snr is not None:

--- a/IM_calculation/examples/waveform_snr.py
+++ b/IM_calculation/examples/waveform_snr.py
@@ -40,7 +40,7 @@ tp = 1320
 # common_freqs = np.logspace(np.log10(0.05), np.log10(50), num=100, base=10.0)
 
 (snr, frequencies, fas_signal, fas_noise, Ds, Dn) = snr_calc.get_snr_from_waveform(
-    waveform, tp, DT, common_frequency_vector=None
+    waveform, tp, (1 / DT), common_frequency_vector=None
 )
 
 if snr is not None:


### PR DESCRIPTION
Allows for the ability to turn on and off smoothing from KO matrices
Applies the cutoff to nan after values going beyond the sampling rate of the data to avoid negative values

Based on the notes here:
[Note on FAS Computation.pdf](https://github.com/ucgmsim/IM_calculation/files/14657688/Note.on.FAS.Computation.pdf)
