### PR TITLE
SNR Overuse Core Issue + KO Matrix Path

### DIFF
--- a/IM_calculation/IM/computeFAS.py
+++ b/IM_calculation/IM/computeFAS.py
@@ -16,9 +16,8 @@ from threadpoolctl import threadpool_limits
 
 matrices = {}
 matrix_lock = Lock()
-
-# Limit the number of threads used by numpy and scipy
-threadpool_limits(limits=1, user_api='blas')
+# Limit the number of threads for loading KO matrices
+threadpool_limits(limits=1, user_api="blas")
 
 
 def get_konno_matrix(size: int, directory: Path = None):
@@ -53,12 +52,13 @@ def get_fourier_spectrum(
     waveform: np.ndarray,
     dt: float = 0.005,
     fa_frequencies_int: List[float] = np.logspace(-1, 2, num=100, base=10.0),
+    konno_matrix_path: Path = None,
 ):
     fa_spectrum, fa_frequencies = generate_fa_spectrum(waveform, dt, waveform.shape[0])
     fa_spectrum = np.abs(fa_spectrum)
 
     # get appropriate konno ohmachi matrix
-    konno = get_konno_matrix(len(fa_spectrum))
+    konno = get_konno_matrix(len(fa_spectrum), konno_matrix_path)
 
     # apply konno ohmachi smoothing
     fa_smooth = np.dot(fa_spectrum.T, konno).T

--- a/IM_calculation/IM/computeFAS.py
+++ b/IM_calculation/IM/computeFAS.py
@@ -12,9 +12,13 @@ from typing import List
 
 import numpy as np
 from scipy.interpolate import interp1d
+from threadpoolctl import threadpool_limits
 
 matrices = {}
 matrix_lock = Lock()
+
+# Limit the number of threads used by numpy and scipy
+threadpool_limits(limits=1, user_api='blas')
 
 
 def get_konno_matrix(size: int, directory: Path = None):

--- a/IM_calculation/IM/im_calculation.py
+++ b/IM_calculation/IM/im_calculation.py
@@ -162,6 +162,8 @@ def compute_measure_single(
     im_options: a dictionary of options for each IM
     comps_to_calculate: the IM components of the input waveforms (e.g. 000, 090)
     progress: a tuple containing station number and total number of stations
+    logger: the logging object
+    ko_matrices_path: the path to the KO matrices, by default None
     :return: {result[station_name]: {[im]: value or (period,value}}
     """
     waveform_acc, waveform_vel = waveform

--- a/IM_calculation/IM/im_calculation.py
+++ b/IM_calculation/IM/im_calculation.py
@@ -1,24 +1,23 @@
 import csv
 import glob
 import os
-import sys
 import shutil
+import sys
 from datetime import datetime
 from functools import partial
 from pathlib import Path
-from typing import List, Iterable
+from typing import Iterable, List
 
 import numpy as np
 import pandas as pd
-
-from qcore import timeseries, constants, shared, qclogging
 from qcore.constants import Components
 from qcore.im import order_im_cols_df
-from IM_calculation.Advanced_IM import advanced_IM_factory
-from IM_calculation.IM import read_waveform, intensity_measures
-from IM_calculation.IM.intensity_measures import G
-from IM_calculation.IM.computeFAS import get_fourier_spectrum
 
+from IM_calculation.Advanced_IM import advanced_IM_factory
+from IM_calculation.IM import intensity_measures, read_waveform
+from IM_calculation.IM.computeFAS import get_fourier_spectrum
+from IM_calculation.IM.intensity_measures import G
+from qcore import constants, qclogging, shared, timeseries
 
 DEFAULT_IMS = ("PGA", "PGV", "CAV", "AI", "Ds575", "Ds595", "MMI", "pSA")
 ALL_IMS = (
@@ -153,6 +152,7 @@ def compute_measure_single(
     comps_to_calculate,
     progress=None,
     logger=qclogging.get_basic_logger(),
+    ko_matrices_path: Path = None,
 ):
     """
     Compute measures for a single station
@@ -195,7 +195,10 @@ def compute_measure_single(
             calculate_SDI,
             (DT, accelerations, im_options, result, station_name, waveform_acc),
         ),
-        "FAS": (calc_FAS, (DT, accelerations, im_options, result, station_name)),
+        "FAS": (
+            calc_FAS,
+            (DT, accelerations, im_options, result, station_name, ko_matrices_path),
+        ),
         "AI": (calc_AI, (accelerations, times)),
         "SED": (calc_SED, (velocities, times)),
         "MMI": (calc_MMI, (velocities,)),
@@ -301,12 +304,15 @@ def calc_FAS(
     im_options,
     result,
     station_name,
+    ko_matrices_path: Path,
     im,
     comps_to_store,
     comps_to_calculate,
 ):
     try:
-        value = get_fourier_spectrum(accelerations[:, :2], DT, im_options[im])
+        value = get_fourier_spectrum(
+            accelerations[:, :2], DT, im_options[im], ko_matrices_path
+        )
         values_to_store = array_to_dict(value, comps_to_calculate, im, comps_to_store)
         if check_rotd(comps_to_store):
             func = lambda rotated_waveform: get_fourier_spectrum(
@@ -321,16 +327,16 @@ def calc_FAS(
     else:
         # compute EAS, the euclidean distance of FAS 000 and 090
         if Components.ceas in comps_to_store:
-            values_to_store[
-                Components.ceas.str_value
-            ] = intensity_measures.get_euclidean_dist(value[:, 0], value[:, 1])
+            values_to_store[Components.ceas.str_value] = (
+                intensity_measures.get_euclidean_dist(value[:, 0], value[:, 1])
+            )
 
         for comp in comps_to_store:
             if comp.str_value in values_to_store:
                 for i, val in enumerate(im_options[im]):
-                    result[(station_name, comp.str_value)][
-                        f"{im}_{str(val)}"
-                    ] = values_to_store[comp.str_value][i]
+                    result[(station_name, comp.str_value)][f"{im}_{str(val)}"] = (
+                        values_to_store[comp.str_value][i]
+                    )
 
 
 def calculate_pSAs(
@@ -631,8 +637,9 @@ def compute_measures_multiprocess(
     :return:
     """
     # Multiprocess imports
-    from multiprocessing.pool import Pool
     from collections import ChainMap
+    from multiprocessing.pool import Pool
+
     from qcore.progress_tracker import ProgressTracker
 
     #  for running adv_im

--- a/IM_calculation/IM/snr_calculation.py
+++ b/IM_calculation/IM/snr_calculation.py
@@ -122,7 +122,7 @@ def get_snr_from_waveform(
     inter_noise[common_frequency_vector > sampling_rate / 2] = np.nan
 
     # Calculate the SNR
-    with np.errstate(divide='ignore'):
+    with np.errstate(divide='ignore', invalid='ignore'):
         snr = (inter_signal / np.sqrt(signal_duration)) / (
             inter_noise / np.sqrt(noise_duration)
         )

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,6 +40,7 @@ pipeline {
                     echo "[ Python used ] : " `which python`
                     echo "[ Installing ${env.JOB_NAME} ]"
 # full installation is not possible as it takes more than 3.0Gb for building and kills the server
+                    cd ${env.WORKSPACE}/../
                     pip install -e IM_calculation
                     cd ${env.WORKSPACE}
 		            python konno_setup.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pandas
 PyYAML
 Scipy
 Cython
+threadpoolctl


### PR DESCRIPTION
This fixes the issue when running snr_calculation and probably im_calculation when computing FAS under multiprocessing it trys to utilize every core per process and so sends the load average into ridiculous numbers above 400 on hypocentre that I was seeing.
However I'm not 100% familiar with all the details of using threadpool_limits(limits=1, user_api="blas") here. Keen for thoughts on this, can test other methods, but this is the first method I found that works without major re-works.

Added the ability to specify your own ko_matrix_path for IM calculations which is useful for the NZGMDB and probbaly general use when you dont want your large KO files in your IM_calc environment location due to space.
I did not clean up all of the docstrings for this where there was no docstring, this entire repo needs a good clean but it's not top priority at the moment.

Added extra ignore for snr calc that was missed.