### PR TITLE
Single Core help

### DIFF
--- a/IM/im_calculation.py
+++ b/IM/im_calculation.py
@@ -169,7 +169,7 @@ def calculate_ims(
         If the IM is not recognized.
     """
     # Set the number of cores
-    # ims.set_cores(cores)
+    ims.set_cores(cores)
 
     results = []
 

--- a/IM/im_calculation.py
+++ b/IM/im_calculation.py
@@ -1,5 +1,5 @@
-import os
 import multiprocessing
+import os
 
 import numpy as np
 import pandas as pd

--- a/IM/im_calculation.py
+++ b/IM/im_calculation.py
@@ -168,6 +168,9 @@ def calculate_ims(
     ValueError
         If the IM is not recognized.
     """
+    # Set the number of cores
+    ims.set_cores(cores)
+
     results = []
 
     # Iterate through IMs and calculate them

--- a/IM/im_calculation.py
+++ b/IM/im_calculation.py
@@ -1,3 +1,4 @@
+import os
 import multiprocessing
 
 import numpy as np
@@ -166,8 +167,20 @@ def calculate_ims(
     Raises
     ------
     ValueError
-        If the IM is not recognized.
+        If the IM is not recognized or if required environment variables are not set to 1.
     """
+    if cores == 1:
+        required_env_vars = [
+            "NUMEXPR_NUM_THREADS",
+            "NUMBA_MAX_THREADS",
+            "NUMBA_NUM_THREADS",
+            "OPENBLAS_NUM_THREADS",
+        ]
+        unset_vars = [var for var in required_env_vars if os.getenv(var) != "1"]
+        if unset_vars:
+            raise ValueError(
+                f"The following environment variables must be set to 1: {', '.join(unset_vars)}"
+            )
     results = []
 
     # Iterate through IMs and calculate them

--- a/IM/im_calculation.py
+++ b/IM/im_calculation.py
@@ -169,7 +169,7 @@ def calculate_ims(
         If the IM is not recognized.
     """
     # Set the number of cores
-    ims.set_cores(cores)
+    # ims.set_cores(cores)
 
     results = []
 

--- a/IM/im_calculation.py
+++ b/IM/im_calculation.py
@@ -168,9 +168,6 @@ def calculate_ims(
     ValueError
         If the IM is not recognized.
     """
-    # Set the number of cores
-    ims.set_cores(cores)
-
     results = []
 
     # Iterate through IMs and calculate them

--- a/IM/ims.py
+++ b/IM/ims.py
@@ -556,6 +556,7 @@ def _cumulative_absolute_velocity(
     ----------
     .. [0] https://stackoverflow.com/questions/79164983/numerically-integrating-signals-with-absolute-value/79173972#79173972
     """
+    print(f"Numba is using {numba.get_num_threads()} threads")
     cav = np.zeros((waveform.shape[0],), dtype=np.float32)
     dtf = np.float32(dt)
     half = np.float32(0.5)

--- a/IM/ims.py
+++ b/IM/ims.py
@@ -61,11 +61,11 @@ def set_cores(cores: int = multiprocessing.cpu_count()) -> None:
     assert cores <= multiprocessing.cpu_count(), "Number of cores exceeds maximum available."
 
     # Set environment variables for NumExpr
-    os.environ['NUMEXPR_NUM_THREADS'] = str(cores)
+    # os.environ['NUMEXPR_NUM_THREADS'] = str(cores)
     ne.set_num_threads(cores)
 
     # Set environment variables for Numba
-    os.environ['NUMBA_NUM_THREADS'] = str(cores)
+    # os.environ['NUMBA_NUM_THREADS'] = str(cores)
     numba.set_num_threads(cores)
 
 

--- a/IM/ims.py
+++ b/IM/ims.py
@@ -71,6 +71,10 @@ def set_cores(cores: int = multiprocessing.cpu_count()) -> None:
     # Needed for matrix multiplication in NumPy during FAS
     os.environ["OPENBLAS_NUM_THREADS"] = str(cores)
 
+    # Print usage
+    print(f"NumExpr is using {ne.get_num_threads()} threads")
+    print(f"Numba is using {numba.get_num_threads()} threads")
+
 
 @numba.njit
 def newmark_estimate_psa(
@@ -319,8 +323,6 @@ def compute_intensity_measure_rotd(
         DataFrame containing intensity measure statistics. Each row represents
         statistics for a single station.
     """
-    print(f"NumExpr is using {ne.ncores} cores")
-    print(f"NumExpr is using {ne.get_num_threads()} threads")
     (stations, _, _) = waveforms.shape
     values = np.zeros(shape=(stations, 180), dtype=waveforms.dtype)
 
@@ -379,7 +381,6 @@ def trapz(
     This is a parallel implementation equivalent to np.trapz, optimized for
     performance with numba.
     """
-    print(f"Numba is using {numba.get_num_threads()} threads")
     sums = np.zeros((waveforms.shape[0],), np.float32)
     for i in numba.prange(waveforms.shape[0]):
         for j in range(waveforms.shape[1]):
@@ -561,7 +562,6 @@ def _cumulative_absolute_velocity(
     ----------
     .. [0] https://stackoverflow.com/questions/79164983/numerically-integrating-signals-with-absolute-value/79173972#79173972
     """
-    print(f"Numba is using {numba.get_num_threads()} threads")
     cav = np.zeros((waveform.shape[0],), dtype=np.float32)
     dtf = np.float32(dt)
     half = np.float32(0.5)
@@ -599,7 +599,6 @@ def _arias_intensity(
     ndarray of float32 with shape `(n_stations,)`
         AI values for each waveform (m/s).
     """
-    print(f"Numba is using {numba.get_num_threads()} threads")
     ai = np.zeros((waveform.shape[0],), dtype=np.float32)
     dtf = np.float32(dt)
     half = np.float32(0.5)

--- a/IM/ims.py
+++ b/IM/ims.py
@@ -43,33 +43,21 @@ class IM(StrEnum):
     pSA = "pSA"  # noqa: N815
     FAS = "FAS"
 
-def set_cores(cores: int = multiprocessing.cpu_count()) -> None:
+def set_single_core() -> None:
     """
-    Set the number of cores to use for NumExpr and Numba.
-
-    Parameters
-    ----------
-    cores : int, optional
-        Number of cores to use, by default all available cores.
-
-    Raises
-    ------
-    AssertionError
-        If the number of cores exceeds the maximum available.
+    Set environment variables for single-core execution.
     """
-    # Check the number of cores is not above the maximum
-    assert cores <= multiprocessing.cpu_count(), "Number of cores exceeds maximum available."
 
     # Set environment variables for NumExpr
-    os.environ['NUMEXPR_NUM_THREADS'] = str(cores)
+    os.environ['NUMEXPR_NUM_THREADS'] = "1"
 
     # Set environment variables for Numba
-    os.environ['NUMBA_MAX_THREADS'] = str(cores)
-    # os.environ['NUMBA_NUM_THREADS'] = str(cores)
+    os.environ['NUMBA_MAX_THREADS'] = "1"
+    # os.environ['NUMBA_NUM_THREADS'] = "1"
 
     # Set the number of threads for OpenBLAS
     # Needed for matrix multiplication in NumPy during FAS
-    os.environ["OPENBLAS_NUM_THREADS"] = str(cores)
+    os.environ["OPENBLAS_NUM_THREADS"] = "1"
 
     # Print usage
     print(f"NumExpr is using {ne.get_num_threads()} threads")

--- a/IM/ims.py
+++ b/IM/ims.py
@@ -171,6 +171,7 @@ def rotd_psa_values(
     ndarray of float32 with shape `(n_stations, n_periods, 3)`
         Array containing minimum (rotd0), median (rotd50) and maximum (rotd100) PSA values.
     """
+    print(f"NumExpr is using {ne.get_num_threads()} threads")
     theta = np.linspace(0, np.pi, num=180, dtype=np.float32)
     psa = np.zeros((comp_000.shape[0], comp_000.shape[-1], 3), np.float32)
     out = np.zeros((step, *comp_000.shape[1:], 180), np.float32)
@@ -373,6 +374,7 @@ def trapz(
     This is a parallel implementation equivalent to np.trapz, optimized for
     performance with numba.
     """
+    print(f"NumExpr is using {ne.get_num_threads()} threads")
     sums = np.zeros((waveforms.shape[0],), np.float32)
     for i in numba.prange(waveforms.shape[0]):
         for j in range(waveforms.shape[1]):

--- a/IM/ims.py
+++ b/IM/ims.py
@@ -2,7 +2,6 @@
 
 import gc
 import multiprocessing
-import os
 import sys
 import warnings
 from collections.abc import Callable
@@ -42,26 +41,6 @@ class IM(StrEnum):
     AI = "AI"
     pSA = "pSA"  # noqa: N815
     FAS = "FAS"
-
-def set_single_core() -> None:
-    """
-    Set environment variables for single-core execution.
-    """
-
-    # Set environment variables for NumExpr
-    os.environ['NUMEXPR_NUM_THREADS'] = "1"
-
-    # Set environment variables for Numba
-    os.environ['NUMBA_MAX_THREADS'] = "1"
-    # os.environ['NUMBA_NUM_THREADS'] = "1"
-
-    # Set the number of threads for OpenBLAS
-    # Needed for matrix multiplication in NumPy during FAS
-    os.environ["OPENBLAS_NUM_THREADS"] = "1"
-
-    # Print usage
-    print(f"NumExpr is using {ne.get_num_threads()} threads")
-    print(f"Numba is using {numba.get_num_threads()} threads")
 
 
 @numba.njit
@@ -166,7 +145,6 @@ def rotd_psa_values(
     ndarray of float32 with shape `(n_stations, n_periods, 3)`
         Array containing minimum (rotd0), median (rotd50) and maximum (rotd100) PSA values.
     """
-    print(f"NumExpr is using {ne.get_num_threads()} threads")
     theta = np.linspace(0, np.pi, num=180, dtype=np.float32)
     psa = np.zeros((comp_000.shape[0], comp_000.shape[-1], 3), np.float32)
     out = np.zeros((step, *comp_000.shape[1:], 180), np.float32)

--- a/IM/ims.py
+++ b/IM/ims.py
@@ -374,7 +374,7 @@ def trapz(
     This is a parallel implementation equivalent to np.trapz, optimized for
     performance with numba.
     """
-    print(f"NumExpr is using {ne.get_num_threads()} threads")
+    print(f"Numba is using {numba.get_num_threads()} threads")
     sums = np.zeros((waveforms.shape[0],), np.float32)
     for i in numba.prange(waveforms.shape[0]):
         for j in range(waveforms.shape[1]):

--- a/IM/ims.py
+++ b/IM/ims.py
@@ -316,6 +316,8 @@ def compute_intensity_measure_rotd(
         DataFrame containing intensity measure statistics. Each row represents
         statistics for a single station.
     """
+    print(f"NumExpr is using {ne.ncores} cores")
+    print(f"NumExpr is using {ne.get_num_threads()} threads")
     (stations, _, _) = waveforms.shape
     values = np.zeros(shape=(stations, 180), dtype=waveforms.dtype)
 

--- a/IM/ims.py
+++ b/IM/ims.py
@@ -596,6 +596,7 @@ def _arias_intensity(
     ndarray of float32 with shape `(n_stations,)`
         AI values for each waveform (m/s).
     """
+    print(f"Numba is using {numba.get_num_threads()} threads")
     ai = np.zeros((waveform.shape[0],), dtype=np.float32)
     dtf = np.float32(dt)
     half = np.float32(0.5)

--- a/IM/ims.py
+++ b/IM/ims.py
@@ -61,12 +61,15 @@ def set_cores(cores: int = multiprocessing.cpu_count()) -> None:
     assert cores <= multiprocessing.cpu_count(), "Number of cores exceeds maximum available."
 
     # Set environment variables for NumExpr
-    # os.environ['NUMEXPR_NUM_THREADS'] = str(cores)
-    ne.set_num_threads(cores)
+    os.environ['NUMEXPR_NUM_THREADS'] = str(cores)
 
     # Set environment variables for Numba
-    # os.environ['NUMBA_NUM_THREADS'] = str(cores)
-    numba.set_num_threads(cores)
+    os.environ['NUMBA_MAX_THREADS'] = str(cores)
+    os.environ['NUMBA_NUM_THREADS'] = str(cores)
+
+    # Set the number of threads for OpenBLAS
+    # Needed for matrix multiplication in NumPy during FAS
+    os.environ["OPENBLAS_NUM_THREADS"] = str(cores)
 
 
 @numba.njit

--- a/IM/ims.py
+++ b/IM/ims.py
@@ -65,7 +65,7 @@ def set_cores(cores: int = multiprocessing.cpu_count()) -> None:
 
     # Set environment variables for Numba
     os.environ['NUMBA_MAX_THREADS'] = str(cores)
-    os.environ['NUMBA_NUM_THREADS'] = str(cores)
+    # os.environ['NUMBA_NUM_THREADS'] = str(cores)
 
     # Set the number of threads for OpenBLAS
     # Needed for matrix multiplication in NumPy during FAS

--- a/IM/ims.py
+++ b/IM/ims.py
@@ -2,6 +2,7 @@
 
 import gc
 import multiprocessing
+import os
 import sys
 import warnings
 from collections.abc import Callable
@@ -41,6 +42,31 @@ class IM(StrEnum):
     AI = "AI"
     pSA = "pSA"  # noqa: N815
     FAS = "FAS"
+
+def set_cores(cores: int = multiprocessing.cpu_count()) -> None:
+    """
+    Set the number of cores to use for NumExpr and Numba.
+
+    Parameters
+    ----------
+    cores : int, optional
+        Number of cores to use, by default all available cores.
+
+    Raises
+    ------
+    AssertionError
+        If the number of cores exceeds the maximum available.
+    """
+    # Check the number of cores is not above the maximum
+    assert cores <= multiprocessing.cpu_count(), "Number of cores exceeds maximum available."
+
+    # Set environment variables for NumExpr
+    os.environ['NUMEXPR_NUM_THREADS'] = str(cores)
+    ne.set_num_threads(cores)
+
+    # Set environment variables for Numba
+    os.environ['NUMBA_NUM_THREADS'] = str(cores)
+    numba.set_num_threads(cores)
 
 
 @numba.njit

--- a/IM/snr_calculation.py
+++ b/IM/snr_calculation.py
@@ -113,11 +113,6 @@ def calculate_snr(
         taper_noise_acc, dt, frequencies, cores, ko_bandwidth
     )
 
-    # Set values to NaN if they are outside the bounds of sample rate / 2
-    sample_rate = 1 / dt
-    fas_signal[:, :, frequencies > sample_rate / 2] = np.nan
-    fas_noise[:, :, frequencies > sample_rate / 2] = np.nan
-
     # Calculate the SNR
     with np.errstate(divide="ignore", invalid="ignore"):
         snr = (fas_signal / np.sqrt(signal_duration)) / (


### PR DESCRIPTION
Ensures if a user is running IM_calc at 1 core checks that the appropriate env variables are set to do so and if not throws an error.

Removes the need to nan the SNR output from FAS as that's done in FAS calc already