### PR TITLE
Expose ko-matrix script to command line.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ exclude = ["wiki", "tests"]
 
 [project.scripts]
 calculate-ims-ascii = "IM.scripts.calculate_ims:app"
+gen-ko-matrices = "IM.scripts.gen_ko_matrix:app"
 
 [tool.ruff.lint]
 extend-select = [


### PR DESCRIPTION
Small PR, just adds a `pyproject.toml` entry so that the `gen_ko_matrix` routines can be run from the command line instead of needing to import them. You can run with

``` shell
gen-ko-matrices /path/to/ko/matrix/directory --num_to_gen 14 --bandwidth 40
```