### PR TITLE
Fixes pSA calcs using too much memory

### DIFF
--- a/IM/ims.py
+++ b/IM/ims.py
@@ -54,9 +54,9 @@ class RotdPsaValuesOutput:
     """ndarray of float32 with shape `(n_stations, n_periods, 3)`
        Array containing minimum (rotd0), median (rotd50) and maximum (rotd100) PSA values."""
     psa_comp_0_maxes: npt.NDArray[np.float32]
-    """Maximum pSA values for the 000 component."""
+    """Maximum absolute displacement values for the 000 component."""
     psa_comp_90_maxes: npt.NDArray[np.float32]
-    """Maximum pSA values for the 090 component."""
+    """Maximum absolute displacement values for the 090 component."""
 
 
 @numba.njit(cache=True)

--- a/IM/ims.py
+++ b/IM/ims.py
@@ -314,7 +314,7 @@ def pseudo_spectral_acceleration(
     # (using COMP_90.value+1 for Python's "up to but not including" slice behavior)
     rotd_psa_values_output = rotd_psa_values(
         waveforms[:, :, Component.COMP_0.value : Component.COMP_90.value + 1],
-        dt,
+        np.float32(dt),
         w,
         step=step,
         use_numexpr=use_numexpr,
@@ -335,7 +335,7 @@ def pseudo_spectral_acceleration(
     for i in range(0, waveforms.shape[0], step):
         comp_ver_psa[i : i + step, :] = conversion_factor * np.abs(
             newmark_estimate_psa(
-                waveforms[i : i + step, :, Component.COMP_VER.value], dt, w
+                waveforms[i : i + step, :, Component.COMP_VER.value], np.float32(dt), w
             )
         ).max(axis=1)
 

--- a/IM/ims.py
+++ b/IM/ims.py
@@ -204,7 +204,7 @@ def rotd_psa_values(
             axis=-1,
         ),
         [1, 2, 0],
-    )
+    ).astype(np.float32)
 
     del out
     gc.collect()  # This is required because Python's GC is too lazy to remove the out array when it should

--- a/IM/ims.py
+++ b/IM/ims.py
@@ -300,7 +300,7 @@ def pseudo_spectral_acceleration(
     if psa_rotd_maximum_memory_allocation:
         step = min(
             int(
-                psa_rotd_maximum_memory_allocation / (180 * sys.getsizeof(waveforms[0]))
+                psa_rotd_maximum_memory_allocation / (180 * len(w) * waveforms[0].nbytes)
             ),
             cores,
         )

--- a/tests/test_ims.py
+++ b/tests/test_ims.py
@@ -125,19 +125,15 @@ def test_rotd_psa_values():
     Checks that rotd_psa_values calculates cos(theta) * comp_0 + sin(theta) * comp_90 and maximises correctly by checking the maximum rotated psa value
     is 2 * pi^2 * sqrt(2).
     """
+    w = 2 * np.pi * np.array([1.0])
+    comp_0 = np.atleast_3d(np.ones((2, 100), dtype=np.float32))
+    comp_90 = np.atleast_3d(np.ones((2, 100), dtype=np.float32))
 
-    sample_waveforms = np.ones((2, 3, 2), dtype=np.float32)
-    sample_dt = np.float32(0.1)
+    result = ims.rotd_psa_values(comp_0, comp_90, w, 3)
 
-    w = 2 * np.pi * np.array([1.0], dtype=np.float32)
-
-    out = ims.rotd_psa_values(sample_waveforms, sample_dt, w, step=1)
-    rotd_psa = out.rotd_psa
-
-    # Expect (n_stations=2, n_freqs=1, percentiles=3)
-    assert rotd_psa.shape == (2, 1, 3)
-    # Check one numerical value
-    assert rotd_psa[0, 0, 2] == pytest.approx(0.8880277276039124, abs=1e-3)
+    # Shape checks
+    assert result.shape == (len(comp_0), len(w), 3)
+    assert result[0, 0, 2] == pytest.approx((2 * np.pi) ** 2 * np.sqrt(2), abs=1e-3)
 
 
 # Test cases for significant duration

--- a/tests/test_ims.py
+++ b/tests/test_ims.py
@@ -120,7 +120,7 @@ def test_rotd_psa_values():
     comp_0 = np.atleast_3d(np.ones((2, 100), dtype=np.float32))
     comp_90 = np.atleast_3d(np.ones((2, 100), dtype=np.float32))
 
-    result = ims.rotd_psa_values(comp_0, comp_90, w, 3)
+    result = ims.rotd_psa_values(comp_0, comp_90, w)
 
     # Shape checks
     assert result.shape == (len(comp_0), len(w), 3)
@@ -269,7 +269,7 @@ def test_psa(use_numexpr: bool):
     waveforms = np.zeros((2, len(comp_0), 3), dtype=np.float32)
     waveforms[0, :, ims.Component.COMP_0] = comp_0
     waveforms[1, :, ims.Component.COMP_0] = comp_0
-    dt = 0.01
+    dt = np.float32(0.01)
     w = np.array([1, 2], dtype=np.float32)
     psa_values = ims.pseudo_spectral_acceleration(
         waveforms, w, dt, use_numexpr=use_numexpr
@@ -547,7 +547,10 @@ def test_invalid_memory_allocation():
 
     with pytest.raises(ValueError, match="PSA rotd memory allocation is too small"):
         ims.pseudo_spectral_acceleration(
-            waveforms, periods, 0.01, psa_rotd_maximum_memory_allocation=1e-10
+            waveforms,
+            periods,
+            np.float32(0.01),
+            psa_rotd_maximum_memory_allocation=1e-10,
         )
 
 

--- a/tests/test_ims.py
+++ b/tests/test_ims.py
@@ -40,6 +40,13 @@ def generate_ko_matrices(request: pytest.FixtureRequest):
     request.addfinalizer(remove_ko_matrices)
 
 
+# Common test fixtures
+@pytest.fixture
+def sample_time():
+    """Generate sample time array."""
+    return np.arange(0, 1, 0.01, dtype=np.float32)
+
+
 @pytest.fixture
 def sample_dt() -> np.float32:
     """Generate sample time step for testing."""
@@ -171,7 +178,7 @@ def test_significant_duration(
     ],
 )
 def test_pga(comp_0: npt.NDArray[np.float32], expected_pga: float, use_numexpr: bool):
-    waveforms = np.zeros((1, len(comp_0), 3))
+    waveforms = np.zeros((1, len(comp_0), 3), dtype=np.float32)
     waveforms[:, :, ims.Component.COMP_0] = comp_0
     assert np.isclose(
         ims.peak_ground_acceleration(waveforms, use_numexpr=use_numexpr)["000"],
@@ -205,7 +212,7 @@ def test_pgv(
     expected_pga: float,
     use_numexpr: bool,
 ):
-    waveforms = np.zeros((1, len(comp_0), 3))
+    waveforms = np.zeros((1, len(comp_0), 3), dtype=np.float32)
     waveforms[:, :, ims.Component.COMP_0] = comp_0
     # NOTE: This dt calculation is correct, if dt = 1 / len(comp_0) then dt
     # ends up *too small* and these tests will fail.
@@ -241,7 +248,7 @@ def test_cav(
     expected_cav: float,
     expected_cav5: Optional[float],
 ):
-    waveforms = np.zeros((1, len(comp_0), 3))
+    waveforms = np.zeros((1, len(comp_0), 3), dtype=np.float32)
     waveforms[:, :, ims.Component.COMP_0] = comp_0
     dt = t_max / (len(comp_0) - 1)
     assert np.isclose(
@@ -263,7 +270,7 @@ def test_cav(
     ],
 )
 def test_ai_values(comp_0: npt.NDArray[np.float32], t_max: float, expected_ai: float):
-    waveforms = np.zeros((1, len(comp_0), 3))
+    waveforms = np.zeros((1, len(comp_0), 3), dtype=np.float32)
     waveforms[:, :, ims.Component.COMP_0] = comp_0
     dt = t_max / (len(comp_0) - 1)
     assert np.isclose(ims.arias_intensity(waveforms, dt)["000"], expected_ai, atol=0.1)
@@ -271,8 +278,8 @@ def test_ai_values(comp_0: npt.NDArray[np.float32], t_max: float, expected_ai: f
 
 @pytest.mark.parametrize("use_numexpr", [True, False])
 def test_psa(use_numexpr: bool):
-    comp_0 = np.ones((100,))
-    waveforms = np.zeros((2, len(comp_0), 3))
+    comp_0 = np.ones((100,), dtype=np.float32)
+    waveforms = np.zeros((2, len(comp_0), 3), dtype=np.float32)
     waveforms[0, :, ims.Component.COMP_0] = comp_0
     waveforms[1, :, ims.Component.COMP_0] = comp_0
     dt = 0.01
@@ -425,8 +432,8 @@ def test_all_ims_benchmark_edge_cases(resource_dir: Path):
 
 @pytest.mark.parametrize("use_numexpr", [True, False])
 def test_ds5xx(use_numexpr: bool):
-    comp_0 = np.ones((100,))
-    waveforms = np.zeros((1, len(comp_0), 3))
+    comp_0 = np.ones((100,), dtype=np.float32)
+    waveforms = np.zeros((1, len(comp_0), 3), dtype=np.float32)
     waveforms[:, :, ims.Component.COMP_0] = comp_0
     # To stop invalid value errors when dividing by zero in other components
     waveforms[:, :, ims.Component.COMP_90] = comp_0 * 2
@@ -490,7 +497,9 @@ def test_arias_intensity(
 # Test cases for Fourier Amplitude Spectra
 @pytest.mark.parametrize("n_freqs", [5, 10])
 def test_fourier_amplitude_spectra(
-    sample_waveforms: npt.NDArray[np.float32], sample_time: np.float32, n_freqs: int
+    sample_waveforms: npt.NDArray[np.float32],
+    sample_time: npt.NDArray[np.float32],
+    n_freqs: int,
 ):
     """Test Fourier Amplitude Spectra calculation."""
     dt = sample_time[1] - sample_time[0]

--- a/tests/test_ims.py
+++ b/tests/test_ims.py
@@ -48,12 +48,6 @@ def sample_time():
 
 
 @pytest.fixture
-def sample_dt() -> np.float32:
-    """Generate sample time step for testing."""
-    return np.float32(0.1)
-
-
-@pytest.fixture
 def sample_waveforms():
     """Generate sample waveform data for testing."""
     t = np.arange(0, 1, 0.01, dtype=np.float32)
@@ -92,17 +86,18 @@ def sample_periods():
 )
 def test_newmark_estimate_psa(
     sample_waveforms: npt.NDArray[np.float32],
-    sample_dt: np.float32,
+    sample_time: npt.NDArray[np.float32],
     xi: np.float32,
     gamma: np.float32,
     beta: np.float32,
 ):
     """Test Newmark PSA estimation with various parameters."""
+    dt = sample_time[1] - sample_time[0]
     w = 2 * np.pi * np.array([1.0, 2.0], dtype=np.float32)
 
     result = ims.newmark_estimate_psa(
         sample_waveforms[:, :, ims.Component.COMP_0],
-        sample_dt,
+        dt,
         w,
         xi=xi,
         gamma=gamma,
@@ -110,11 +105,7 @@ def test_newmark_estimate_psa(
     )
 
     # Basic checks
-    assert result.shape == (
-        sample_waveforms.shape[0],
-        sample_waveforms.shape[1],
-        len(w),
-    )
+    assert result.shape == (len(sample_waveforms), len(sample_time), len(w))
     assert not np.any(np.isnan(result))
     assert not np.any(np.isinf(result))
 

--- a/tests/test_ims.py
+++ b/tests/test_ims.py
@@ -127,9 +127,6 @@ def test_rotd_psa_values():
     out = ims.rotd_psa_values(sample_waveforms, sample_dt, w, step=1)
     rotd_psa = out.rotd_psa
 
-    print("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
-    print("results:")
-    print(rotd_psa)
     # Expect (n_stations=2, n_freqs=1, percentiles=3)
     assert rotd_psa.shape == (2, 1, 3)
     # Check one numerical value

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -62,7 +62,7 @@ def test_calculate_ims_ascii_invalid_file():
 
     # Assertions
     assert result.exit_code != 0
-    assert "Usage:" in result.stdout
+    assert "Usage:" in result.stderr
 
 
 def test_calculate_ims_ascii_empty_ims_list(tmp_path: Path):
@@ -90,4 +90,4 @@ def test_calculate_ims_ascii_empty_ims_list(tmp_path: Path):
 
     # Assertions
     assert result.exit_code != 0
-    assert "Usage:" in result.stdout
+    assert "Usage:" in result.stderr


### PR DESCRIPTION
Cesar encountered an issue where the pSA calculation was being killed for using too much memory. 

The issue was that `comp_0 = newmark_estimate_psa(
        waveforms[:, :, Component.COMP_0.value],
        t,
        dt,
        w,
    )`

    
   (and the 90 and vertical components) were trying to process waveforms for all stations at once. `rotd_psa_values()` was already processing the stations in smaller batches that didn't overwhelm the memory, so I called `newmark_estimate_psa()` in the same way.
   
The outputs of some functions changed, so I also updated those tests. The test for the correct numerical value in `test_rotd_psa_values()` is not very robust, so suggestions are welcome