### PR TITLE
Snr calc fix

### DIFF
--- a/IM/snr_calculation.py
+++ b/IM/snr_calculation.py
@@ -101,9 +101,6 @@ def calculate_snr(
         * noise_acc[:]
     )
 
-    # Add an assertion check to ensure that the tapering did not affect the signal at tp
-    assert np.all(signal_acc[0, tp_extra] == taper_signal_acc[0, tp_extra])
-
     # Ensure float 32 for the waveform
     taper_signal_acc = taper_signal_acc.astype(np.float32)
     taper_noise_acc = taper_noise_acc.astype(np.float32)


### PR DESCRIPTION
Ensures that when using tp_extra that we don't get a negative number and trail to the end of the waveform.
Had to remove the assert as these cases will now adjust the values at tp